### PR TITLE
Health system

### DIFF
--- a/include/Engine/Core/EPlayerDamage.h
+++ b/include/Engine/Core/EPlayerDamage.h
@@ -9,8 +9,8 @@ namespace Events
 
 struct PlayerDamage : Event
 {
-    int DamageAmount;
-    EntityID PlayerID;
+    double DamageAmount;
+    EntityID PlayerDamagedID;
 };
 
 }

--- a/include/Engine/Core/EPlayerDamage.h
+++ b/include/Engine/Core/EPlayerDamage.h
@@ -11,6 +11,8 @@ struct PlayerDamage : Event
 {
     double DamageAmount;
     EntityID PlayerDamagedID;
+    //optional TypeOfDamage
+    std::string TypeOfDamage;
 };
 
 }

--- a/include/Engine/Core/EPlayerDamage.h
+++ b/include/Engine/Core/EPlayerDamage.h
@@ -1,0 +1,18 @@
+#ifndef EPlayerDamage_h__
+#define EPlayerDamage_h__
+
+#include "EventBroker.h"
+#include "../Core/Entity.h"
+
+namespace Events
+{
+
+struct PlayerDamage : Event
+{
+    int DamageAmount;
+    EntityID PlayerID;
+};
+
+}
+
+#endif

--- a/include/Engine/Core/EPlayerDeath.h
+++ b/include/Engine/Core/EPlayerDeath.h
@@ -1,0 +1,18 @@
+#ifndef EPlayerDeath_h__
+#define EPlayerDeath_h__
+
+#include "EventBroker.h"
+#include "../Core/Entity.h"
+
+namespace Events
+{
+
+struct PlayerDeath : Event
+{
+    std::string KilledBy;
+    EntityID PlayerID;
+};
+
+}
+
+#endif

--- a/include/Engine/Core/EPlayerDeath.h
+++ b/include/Engine/Core/EPlayerDeath.h
@@ -9,8 +9,10 @@ namespace Events
 
 struct PlayerDeath : Event
 {
-    std::string KilledBy;
+    //KilledBy,KilledByWhat is optional for now. It might be used later in the playerlog-system
+    EntityID KilledBy;
     EntityID PlayerID;
+    std::string KilledByWhat;
 };
 
 }

--- a/include/Engine/Core/EPlayerHealthPickup.h
+++ b/include/Engine/Core/EPlayerHealthPickup.h
@@ -1,0 +1,18 @@
+#ifndef EPlayerHealthPickup_h__
+#define EPlayerHealthPickup_h__
+
+#include "EventBroker.h"
+#include "../Core/Entity.h"
+
+namespace Events
+{
+
+struct PlayerHealthPickup : Event
+{
+    int HealthAmount;
+    EntityID HealthPickupID;
+};
+
+}
+
+#endif

--- a/include/Engine/Core/EPlayerHealthPickup.h
+++ b/include/Engine/Core/EPlayerHealthPickup.h
@@ -10,8 +10,7 @@ namespace Events
 struct PlayerHealthPickup : Event
 {
     double HealthAmount;
-    EntityID HealthPickupID;
-    EntityID playerHealedID;
+    EntityID PlayerHealedID;
 };
 
 }

--- a/include/Engine/Core/EPlayerHealthPickup.h
+++ b/include/Engine/Core/EPlayerHealthPickup.h
@@ -9,8 +9,9 @@ namespace Events
 
 struct PlayerHealthPickup : Event
 {
-    int HealthAmount;
+    double HealthAmount;
     EntityID HealthPickupID;
+    EntityID playerHealedID;
 };
 
 }

--- a/include/Game/HealthSystem.h
+++ b/include/Game/HealthSystem.h
@@ -22,13 +22,13 @@ public:
     virtual void UpdateComponent(World* world, ComponentWrapper& health, double dt) override;
 
 private:
-    //create the methods which will take care of specific events
+    //methods which will take care of specific events
     EventRelay<HealthSystem, Events::PlayerDamage> m_EPlayerDamage;
     bool HealthSystem::OnPlayerDamaged(const Events::PlayerDamage& e);
     EventRelay<HealthSystem, Events::PlayerHealthPickup> m_EPlayerHealthPickup;
     bool HealthSystem::OnPlayerHealthPickup(const Events::PlayerHealthPickup& e);
 
-    //create the vector which will keep track of health changes
+    //vector which will keep track of health changes
     std::vector<std::tuple<EntityID, double>> m_DeltaHealthVector;
    
 };

--- a/include/Game/HealthSystem.h
+++ b/include/Game/HealthSystem.h
@@ -1,0 +1,32 @@
+#ifndef HealthSystem_h__
+#define HealthSystem_h__
+
+#include <GLFW/glfw3.h>
+#include <glm/common.hpp>
+
+#include "Common.h"
+#include "Core/System.h"
+#include "Core\EPlayerDamage.h";
+#include "Core\EPlayerHealthPickup.h";
+#include "Core\EPlayerDeath.h";
+
+class HealthSystem : public PureSystem
+{
+public:
+    HealthSystem(EventBroker* eventBroker);
+
+    virtual void UpdateComponent(World* world, ComponentWrapper& player, double dt) override;
+private:
+    float m_Speed = 5;
+
+    //create the methods which will take care of specific events
+    EventRelay<HealthSystem, Events::PlayerDamage> m_EPlayerDamage;
+    bool HealthSystem::OnPlayerDamaged(const Events::PlayerDamage& e);
+    EventRelay<HealthSystem, Events::PlayerHealthPickup> m_EPlayerHealthPickup;
+    bool HealthSystem::OnPlayerHealthPickup(const Events::PlayerHealthPickup& e);
+
+    int playerDeltaHealth;
+
+};
+
+#endif

--- a/include/Game/HealthSystem.h
+++ b/include/Game/HealthSystem.h
@@ -10,23 +10,27 @@
 #include "Core\EPlayerHealthPickup.h";
 #include "Core\EPlayerDeath.h";
 
+#include <tuple>
+#include <vector>
+
 class HealthSystem : public PureSystem
 {
 public:
     HealthSystem(EventBroker* eventBroker);
 
-    virtual void UpdateComponent(World* world, ComponentWrapper& player, double dt) override;
-private:
-    float m_Speed = 5;
+    //updatecomponent
+    virtual void UpdateComponent(World* world, ComponentWrapper& health, double dt) override;
 
+private:
     //create the methods which will take care of specific events
     EventRelay<HealthSystem, Events::PlayerDamage> m_EPlayerDamage;
     bool HealthSystem::OnPlayerDamaged(const Events::PlayerDamage& e);
     EventRelay<HealthSystem, Events::PlayerHealthPickup> m_EPlayerHealthPickup;
     bool HealthSystem::OnPlayerHealthPickup(const Events::PlayerHealthPickup& e);
 
-    int playerDeltaHealth;
-
+    //create the vector which will keep track of health changes
+    std::vector<std::tuple<EntityID, double>> m_DeltaHealthVector;
+   
 };
 
 #endif

--- a/resources/Schema/Components.xsd
+++ b/resources/Schema/Components.xsd
@@ -8,4 +8,5 @@
 	<xs:include schemaLocation="Components/Player.xsd"/>
 	<xs:include schemaLocation="Components/AABB.xsd"/>
 	<xs:include schemaLocation="Components/Trigger.xsd"/>
+	<xs:include schemaLocation="Components/Health.xsd"/>
 </xs:schema>

--- a/resources/Schema/Components/Health.xml
+++ b/resources/Schema/Components/Health.xml
@@ -1,0 +1,4 @@
+<c:Health>
+	<Health>100</Health>
+	<MaxHealth>100</MaxHealth>
+</c:Health>

--- a/resources/Schema/Components/Health.xsd
+++ b/resources/Schema/Components/Health.xsd
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:t="types">
+	<xs:import schemaLocation="../Types.xsd" namespace="types"/>
+
+	<xs:element name="Health">
+		<xs:complexType>
+			<xs:all>
+				<xs:element name="Health" type="t:double" minOccurs="0"/>
+				<xs:element name="MaxHealth" type="t:double" minOccurs="0"/>
+			</xs:all>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/resources/Schema/Types/Entity.xsd
+++ b/resources/Schema/Types/Entity.xsd
@@ -15,6 +15,7 @@
 							<xs:element ref="c:Test" minOccurs="0"/>
 							<xs:element ref="c:RaptorCopter" minOccurs="0"/>
 							<xs:element ref="c:Player" minOccurs="0"/>
+							<xs:element ref="c:Health" minOccurs="0"/>
 						</xs:all>
 					</xs:complexType>
 				</xs:element>

--- a/src/Engine/Core/EventBroker.cpp
+++ b/src/Engine/Core/EventBroker.cpp
@@ -3,7 +3,7 @@
 BaseEventRelay::~BaseEventRelay()
 {
     if (m_Broker != nullptr) {
-        m_Broker->Unsubscribe(*this);
+		m_Broker->Unsubscribe(*this);
     }
 }
 

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -1,6 +1,7 @@
 #include "Game.h"
 #include "Collision/TriggerSystem.h"
 #include "Collision/CollisionSystem.h"
+#include "Game/HealthSystem.h"
 
 Game::Game(int argc, char* argv[])
 {
@@ -57,6 +58,7 @@ Game::Game(int argc, char* argv[])
     m_SystemPipeline->AddSystem<EditorSystem>(m_Renderer);
     m_SystemPipeline->AddSystem<CollisionSystem>();
     m_SystemPipeline->AddSystem<TriggerSystem>();
+    m_SystemPipeline->AddSystem<HealthSystem>();
 
     // Invoke network
     if (m_Config->Get<bool>("Networking.StartNetwork", false)) {

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -28,7 +28,7 @@ Game::Game(int argc, char* argv[])
         0,
         m_Config->Get<int>("Video.Width", 1280),
         m_Config->Get<int>("Video.Height", 720)
-    ));
+        ));
     m_Renderer->Initialize();
     m_Renderer->Camera()->SetFOV(glm::radians(m_Config->Get<float>("Video.FOV", 90.f)));
 
@@ -60,7 +60,26 @@ Game::Game(int argc, char* argv[])
     m_SystemPipeline->AddSystem<TriggerSystem>();
     m_SystemPipeline->AddSystem<HealthSystem>();
 
-    // Invoke network
+    //TEMP TEST DEL LATER
+    //skapar entityn som har komponenterna transf,model,player,health i sig. dvs är en spelare
+    EntityID playerID = m_World->CreateEntity();
+    ComponentWrapper transform = m_World->AttachComponent(playerID, "Transform");
+    ComponentWrapper model = m_World->AttachComponent(playerID, "Model");
+    model["Resource"] = "Models/Core/UnitSphere.obj";
+    ComponentWrapper player = m_World->AttachComponent(playerID, "Player");
+    ComponentWrapper health = m_World->AttachComponent(playerID, "Health");
+    Events::PlayerDamage e;
+    e.DamageAmount = 50.0f;
+    e.PlayerDamagedID = 9;
+    m_EventBroker->Publish(e);
+    Events::PlayerHealthPickup e2;
+    e2.HealthAmount = 40.0f;
+    e2.playerHealedID = 9;
+    m_EventBroker->Publish(e2);
+
+    //END TEST
+
+        // Invoke network
     if (m_Config->Get<bool>("Networking.StartNetwork", false)) {
         //boost::thread workerThread(&Game::networkFunction, this);
         networkFunction();

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -60,26 +60,7 @@ Game::Game(int argc, char* argv[])
     m_SystemPipeline->AddSystem<TriggerSystem>();
     m_SystemPipeline->AddSystem<HealthSystem>();
 
-    //TEMP TEST DEL LATER
-    //skapar entityn som har komponenterna transf,model,player,health i sig. dvs är en spelare
-    EntityID playerID = m_World->CreateEntity();
-    ComponentWrapper transform = m_World->AttachComponent(playerID, "Transform");
-    ComponentWrapper model = m_World->AttachComponent(playerID, "Model");
-    model["Resource"] = "Models/Core/UnitSphere.obj";
-    ComponentWrapper player = m_World->AttachComponent(playerID, "Player");
-    ComponentWrapper health = m_World->AttachComponent(playerID, "Health");
-    Events::PlayerDamage e;
-    e.DamageAmount = 50.0f;
-    e.PlayerDamagedID = 9;
-    m_EventBroker->Publish(e);
-    Events::PlayerHealthPickup e2;
-    e2.HealthAmount = 40.0f;
-    e2.playerHealedID = 9;
-    m_EventBroker->Publish(e2);
-
-    //END TEST
-
-        // Invoke network
+    // Invoke network
     if (m_Config->Get<bool>("Networking.StartNetwork", false)) {
         //boost::thread workerThread(&Game::networkFunction, this);
         networkFunction();

--- a/src/Game/HealthSystem.cpp
+++ b/src/Game/HealthSystem.cpp
@@ -13,8 +13,7 @@ void HealthSystem::UpdateComponent(World *world, ComponentWrapper &health, doubl
 {
     //if entityID of health is 9 then the players ID is also 9 (player,health are connected to the same entity)
     ComponentWrapper player = world->GetComponent(health.EntityID, "Player");
-    double currentHealth;
-    double maxHealth = (double)world->GetComponent(health.EntityID, "Health")["MaxHealth"];
+    double maxHealth = (double)health["MaxHealth"];
 
     //process the DeltaHealthVector and change the entitys health accordingly
     for (size_t i = m_DeltaHealthVector.size(); i > 0; i--)
@@ -22,18 +21,15 @@ void HealthSystem::UpdateComponent(World *world, ComponentWrapper &health, doubl
         auto deltaHP = m_DeltaHealthVector[i - 1];
         //if we have a healthchange for the current player, then apply it
         if (std::get<0>(deltaHP) == player.EntityID) {
-            //re-read currentHealth for each iteration
-            currentHealth = (double)world->GetComponent(health.EntityID, "Health")["Health"];
             //get the deltaHP value from the tuple and make sure you dont get more than maxHealth
-            double newHealth = std::min(currentHealth + (double)std::get<1>(deltaHP), maxHealth);
-            health.SetProperty("Health", newHealth);
+            double newHealth = std::min((double)health["Health"] + (double)std::get<1>(deltaHP), maxHealth);
+            health["Health"] = newHealth;
             m_DeltaHealthVector.erase(m_DeltaHealthVector.begin() + i - 1);
         }
     }
 
-    currentHealth = (double)world->GetComponent(health.EntityID, "Health")["Health"];
     //check if health is <= 0
-    if (currentHealth <= 0.0f) {
+    if ((double)health["Health"] <= 0.0f) {
         //publish death event
         Events::PlayerDeath e;
         e.PlayerID = player.EntityID;

--- a/src/Game/HealthSystem.cpp
+++ b/src/Game/HealthSystem.cpp
@@ -4,34 +4,36 @@
 HealthSystem::HealthSystem(EventBroker* eventBroker)
     : PureSystem(eventBroker, "Health")
 {
-    //subscribe/listenTo playerdamage,healthpickup events with the eventbroker
+    //subscribe/listenTo playerdamage,healthpickup events (using the eventBroker)
     EVENT_SUBSCRIBE_MEMBER(m_EPlayerDamage, &HealthSystem::OnPlayerDamaged);
     EVENT_SUBSCRIBE_MEMBER(m_EPlayerHealthPickup, &HealthSystem::OnPlayerHealthPickup);
 }
 
-void HealthSystem::UpdateComponent(World * world, ComponentWrapper & health, double dt)
+void HealthSystem::UpdateComponent(World *world, ComponentWrapper &health, double dt)
 {
     //if entityID of health is 9 then the players ID is also 9 (player,health are connected to the same entity)
     ComponentWrapper player = world->GetComponent(health.EntityID, "Player");
-    double currentHealth = (double) world->GetComponent(health.EntityID, "Health")["Health"];
+    double currentHealth;
     double maxHealth = (double)world->GetComponent(health.EntityID, "Health")["MaxHealth"];
 
     //process the DeltaHealthVector and change the entitys health accordingly
-    for (size_t i = m_DeltaHealthVector.size(); i >0; i--)
+    for (size_t i = m_DeltaHealthVector.size(); i > 0; i--)
     {
-        auto deltaHP = m_DeltaHealthVector[i-1];
+        auto deltaHP = m_DeltaHealthVector[i - 1];
+        //if we have a healthchange for the current player, then apply it
         if (std::get<0>(deltaHP) == player.EntityID) {
             //re-read currentHealth for each iteration
             currentHealth = (double)world->GetComponent(health.EntityID, "Health")["Health"];
             //get the deltaHP value from the tuple and make sure you dont get more than maxHealth
             double newHealth = std::min(currentHealth + (double)std::get<1>(deltaHP), maxHealth);
             health.SetProperty("Health", newHealth);
-            m_DeltaHealthVector.erase(m_DeltaHealthVector.begin()+i-1);
+            m_DeltaHealthVector.erase(m_DeltaHealthVector.begin() + i - 1);
         }
     }
 
     currentHealth = (double)world->GetComponent(health.EntityID, "Health")["Health"];
-    if (currentHealth < 0.0f) {
+    //check if health is <= 0
+    if (currentHealth <= 0.0f) {
         //publish death event
         Events::PlayerDeath e;
         e.PlayerID = player.EntityID;
@@ -49,6 +51,6 @@ bool HealthSystem::OnPlayerDamaged(const Events::PlayerDamage& e)
 bool HealthSystem::OnPlayerHealthPickup(const Events::PlayerHealthPickup& e)
 {
     //save the changed HP to a vector. it will be taken care of in UpdateComponent
-    m_DeltaHealthVector.push_back(std::make_tuple(e.playerHealedID, e.HealthAmount));
+    m_DeltaHealthVector.push_back(std::make_tuple(e.PlayerHealedID, e.HealthAmount));
     return true;
 }

--- a/src/Game/HealthSystem.cpp
+++ b/src/Game/HealthSystem.cpp
@@ -1,0 +1,38 @@
+#include "HealthSystem.h"
+
+HealthSystem::HealthSystem(EventBroker* eventBroker)
+    : PureSystem(eventBroker, "Health")
+{
+    //subscribe/listenTo playerdamage,healthpickup events with the eventbroker
+    EVENT_SUBSCRIBE_MEMBER(m_EPlayerDamage, &HealthSystem::OnPlayerDamaged);
+    EVENT_SUBSCRIBE_MEMBER(m_EPlayerHealthPickup, &HealthSystem::OnPlayerHealthPickup);
+    playerDeltaHealth = 0;
+}
+void HealthSystem::UpdateComponent(World * world, ComponentWrapper & player, double dt)
+{
+    //Health is only affected by pickup/shoot events
+    player["Health"] += playerDeltaHealth;
+    playerDeltaHealth = 0;
+    if (player["Health"] < 0) {
+        //sendout/publish death event
+        Events::PlayerDeath e;
+        e.PlayerID = player.EntityID;
+        m_EventBroker->Publish(e);
+    }
+}
+bool HealthSystem::OnPlayerDamaged(const Events::PlayerDamage& e)
+{
+    //vem skadades?
+    //antagligen spelaren själv
+    //såna här events skickas av network te spelare som kan lyssna på / kolla på de och tar hand om sina egna +-hp endast
+    //just add that damage to a variable, which will later be taken care of by UpdateComponent
+    playerDeltaHealth -= e.DamageAmount;
+    //ev skicka ut playerdeath event
+    return true;
+}
+bool HealthSystem::OnPlayerHealthPickup(const Events::PlayerHealthPickup& e)
+{
+    //vem tog upp hp?
+    playerDeltaHealth += e.HealthAmount;
+    return true;
+}

--- a/src/Tests/HealthSystemTest.cpp
+++ b/src/Tests/HealthSystemTest.cpp
@@ -1,0 +1,114 @@
+#include <boost/test/unit_test.hpp>
+using boost::unit_test_framework::test_suite;
+using boost::unit_test_framework::test_case;
+
+#include "HealthSystemTest.h"
+#include "Game/HealthSystem.h"
+
+BOOST_AUTO_TEST_SUITE(HealthSystemSuite)
+
+BOOST_AUTO_TEST_CASE(HealthSystemTest)
+{
+    //this tests 2 healthevents and the healthsystem
+    GameHealthSystemTest game;
+    //100 loops will be more than enough to do the test
+    int loops = 100;
+    bool success = false;
+    while (loops > 0) {
+        game.Tick();
+        if (game.TestSucceeded) {
+            success = true;
+            break;
+        }
+        loops--;
+    }
+    //The system will process the events, hence it will take a while before we can read anything
+    BOOST_TEST(success);
+}
+BOOST_AUTO_TEST_SUITE_END()
+
+GameHealthSystemTest::GameHealthSystemTest()
+{
+    ResourceManager::RegisterType<ConfigFile>("ConfigFile");
+    ResourceManager::RegisterType<EntityXMLFile>("EntityXMLFile");
+
+    m_Config = ResourceManager::Load<ConfigFile>("Config.ini");
+    LOG_LEVEL = static_cast<_LOG_LEVEL>(m_Config->Get<int>("Debug.LogLevel", 1));
+
+    // Create the core event broker
+    m_EventBroker = new EventBroker();
+
+     // Create a world
+    m_World = new World();
+    std::string mapToLoad = m_Config->Get<std::string>("Debug.LoadMap", "");
+    if (!mapToLoad.empty()) {
+        ResourceManager::Load<EntityXMLFile>(mapToLoad)->PopulateWorld(m_World);
+    }
+
+    // Create system pipeline
+    m_SystemPipeline = new SystemPipeline(m_EventBroker);
+    m_SystemPipeline->AddSystem<PlayerSystem>();
+    m_SystemPipeline->AddSystem<HealthSystem>();
+
+    //The Test
+    //create entity which has transorm,player,model,health in it. i.e. is a player
+    EntityID playerID = m_World->CreateEntity();
+    ComponentWrapper transform = m_World->AttachComponent(playerID, "Transform");
+    ComponentWrapper model = m_World->AttachComponent(playerID, "Model");
+    model["Resource"] = "Models/Core/UnitSphere.obj";
+    ComponentWrapper player = m_World->AttachComponent(playerID, "Player");
+    ComponentWrapper health = m_World->AttachComponent(playerID, "Health");
+    healthsID = playerID;
+    double currentHealth = (double)m_World->GetComponent(healthsID, "Health")["Health"];
+
+    //heal player with 40
+    Events::PlayerHealthPickup e3;
+    e3.HealthAmount = 40.0f;
+    e3.PlayerHealedID = healthsID;
+    m_EventBroker->Publish(e3);
+    //damage player with 50
+    Events::PlayerDamage e;
+    e.DamageAmount = 50.0f;
+    e.PlayerDamagedID = healthsID;
+    m_EventBroker->Publish(e);
+    //heal some other player with 40
+    Events::PlayerHealthPickup e2;
+    e2.HealthAmount = 40.0f;
+    e2.PlayerHealedID = healthsID+1;
+    m_EventBroker->Publish(e2);
+
+    EntityID playerID2 = m_World->CreateEntity();
+    ComponentWrapper transform2 = m_World->AttachComponent(playerID2, "Transform");
+    ComponentWrapper model2 = m_World->AttachComponent(playerID2, "Model");
+    model2["Resource"] = "Models/Core/UnitSphere.obj";
+    ComponentWrapper player2 = m_World->AttachComponent(playerID2, "Player");
+    ComponentWrapper health2 = m_World->AttachComponent(playerID2, "Health");
+    //END TEST
+}
+
+GameHealthSystemTest::~GameHealthSystemTest()
+{
+    delete m_SystemPipeline;
+    delete m_World;
+    delete m_EventBroker;
+}
+
+void GameHealthSystemTest::Tick()
+{
+    glfwPollEvents();
+
+    double currentTime = glfwGetTime();
+    double dt = currentTime - m_LastTime;
+    m_LastTime = currentTime;
+
+    // Iterate through systems and update world!
+    m_SystemPipeline->Update(m_World, dt);
+
+    m_EventBroker->Swap();
+    m_EventBroker->Clear();
+
+    //if health reaches 90 then we know the test has succeeded (start with 100hp, remove 50hp, add 40hp)
+    double currentHealth = (double)m_World->GetComponent(healthsID, "Health")["Health"];
+    if (currentHealth==90)
+        TestSucceeded = true;
+}

--- a/src/Tests/HealthSystemTest.h
+++ b/src/Tests/HealthSystemTest.h
@@ -1,0 +1,40 @@
+#ifndef HealthTest_h__
+#define HealthTest_h__
+
+#include "Core/ResourceManager.h"
+#include "Core/ConfigFile.h"
+#include "Core/EventBroker.h"
+#include "Rendering/Renderer.h"
+#include "Core/InputManager.h"
+#include "GUI/Frame.h"
+#include "Core/World.h"
+#include "Rendering/RenderQueueFactory.h"
+#include "Input/InputProxy.h"
+#include "Input/KeyboardInputHandler.h"
+#include "Input/MouseInputHandler.h"
+#include "Core/EKeyDown.h"
+#include "Core/EntityXMLFile.h"
+#include "Core/SystemPipeline.h"
+#include "RaptorCopterSystem.h"
+#include "PlayerSystem.h"
+#include "Editor/EditorSystem.h"
+
+class GameHealthSystemTest
+{
+public:
+    GameHealthSystemTest();
+    ~GameHealthSystemTest();
+
+    void Tick();
+    bool TestSucceeded = false;
+
+private:
+    double m_LastTime;
+    ConfigFile* m_Config = nullptr;
+    EventBroker* m_EventBroker;
+    World* m_World;
+    SystemPipeline* m_SystemPipeline;
+    int healthsID;
+};
+
+#endif


### PR DESCRIPTION
1 new system:
HealthSystem - this updates health for the players (healthDelta from the new events)
3 new events: 
EPlayerDamage - trigger this when player takes damage
EPlayerDeath - HealthSystem triggers this when players hitpoints goes below 0
EPlayerHealthPickup - trigger this when player picks up health
1 new component:
Health - add this to playerEntities
1 new testclass:
HealthSystemTest - this does a small test of 2 of the new events and checks so the health has changed for the player
