### PR TITLE
Ordered system pipeline

### DIFF
--- a/include/Engine/Core/SystemPipeline.h
+++ b/include/Engine/Core/SystemPipeline.h
@@ -15,10 +15,8 @@ public:
     ~SystemPipeline()
     {
         for (UnorderedSystems& group : m_OrderedSystemGroups) {
-            for (auto& pair : group.PureSystems) {
-                for (auto& system : pair.second) {
-                    delete system;
-                }
+            for (auto& pair : group.Systems) {
+                delete pair.second;
             }
         }
     }

--- a/include/Engine/Core/SystemPipeline.h
+++ b/include/Engine/Core/SystemPipeline.h
@@ -14,23 +14,29 @@ public:
     { }
     ~SystemPipeline()
     {
-        for (auto& pair : m_PureSystems) {
-            for (auto& system : pair.second) {
-                delete system;
+        for (UnorderedSystems& group : m_OrderedSystemGroups) {
+            for (auto& pair : group.PureSystems) {
+                for (auto& system : pair.second) {
+                    delete system;
+                }
             }
         }
     }
 
     template <typename T, typename... Arguments>
-    void AddSystem(Arguments... args)
+    void AddSystem(int updateOrderPriority, Arguments... args)
     {
+        if (updateOrderPriority + 1 > m_OrderedSystemGroups.size()) {
+            m_OrderedSystemGroups.resize(updateOrderPriority + 1);
+        }
+        UnorderedSystems& group = m_OrderedSystemGroups[updateOrderPriority];
         System* system = new T(m_EventBroker, args...);
-        m_Systems[typeid(T).name()] = system;
+        group.Systems[typeid(T).name()] = system;
 
         if (std::is_base_of<PureSystem, T>::value) {
             PureSystem* pureSystem = static_cast<PureSystem*>(system);
             if (!pureSystem->m_ComponentType.empty()) {
-                m_PureSystems[pureSystem->m_ComponentType].push_back(pureSystem);
+                group.PureSystems[pureSystem->m_ComponentType].push_back(pureSystem);
             } else {
                 LOG_ERROR("Failed to add pure system \"%s\": Missing component type!", typeid(T).name());
             }
@@ -38,41 +44,47 @@ public:
 
         if (std::is_base_of<ImpureSystem, T>::value) {
             ImpureSystem* impureSystem = static_cast<ImpureSystem*>(system);
-            m_ImpureSystems.push_back(impureSystem);
+            group.ImpureSystems.push_back(impureSystem);
         }
     }
 
     void Update(World* world, double dt)
     {
-        // Process events
-        for (auto& pair : m_Systems) {
-            m_EventBroker->Process(pair.first);
-        }
-
-        // Update
-        for (auto& pair : m_PureSystems) {
-            const std::string& componentName = pair.first;
-            auto& systems = pair.second;
-            const ComponentPool* pool = world->GetComponents(componentName);
-            if (pool == nullptr) {
-                continue;
+        for (UnorderedSystems& group : m_OrderedSystemGroups) {
+            // Process events
+            for (auto& pair : group.Systems) {
+                m_EventBroker->Process(pair.first);
             }
-            for (auto& component : *pool) {
-                for (auto& system : systems) {
-                    system->UpdateComponent(world, component, dt);
+
+            // Update
+            for (auto& pair : group.PureSystems) {
+                const std::string& componentName = pair.first;
+                auto& systems = pair.second;
+                const ComponentPool* pool = world->GetComponents(componentName);
+                if (pool == nullptr) {
+                    continue;
+                }
+                for (auto& component : *pool) {
+                    for (auto& system : systems) {
+                        system->UpdateComponent(world, component, dt);
+                    }
                 }
             }
-        }
-        for (auto& system : m_ImpureSystems) {
-            system->Update(world, dt);
+            for (auto& system : group.ImpureSystems) {
+                system->Update(world, dt);
+            }
         }
     }
 
 private:
     EventBroker* m_EventBroker;
-    std::map<std::string, System*> m_Systems;
-    std::map<std::string, std::vector<PureSystem*>> m_PureSystems;
-    std::vector<ImpureSystem*> m_ImpureSystems;
+    struct UnorderedSystems
+    {
+        std::map<std::string, System*> Systems;
+        std::map<std::string, std::vector<PureSystem*>> PureSystems;
+        std::vector<ImpureSystem*> ImpureSystems;
+    };
+    std::vector<UnorderedSystems> m_OrderedSystemGroups;
 };
 
 #endif

--- a/include/Engine/Core/SystemPipeline.h
+++ b/include/Engine/Core/SystemPipeline.h
@@ -24,12 +24,13 @@ public:
     }
 
     template <typename T, typename... Arguments>
-    void AddSystem(int updateOrderPriority, Arguments... args)
+    //All systems with orderlevel 0 will be updated first, then 1, 2, etc.
+    void AddSystem(int updateOrderLevel, Arguments... args)
     {
-        if (updateOrderPriority + 1 > m_OrderedSystemGroups.size()) {
-            m_OrderedSystemGroups.resize(updateOrderPriority + 1);
+        if (updateOrderLevel + 1 > m_OrderedSystemGroups.size()) {
+            m_OrderedSystemGroups.resize(updateOrderLevel + 1);
         }
-        UnorderedSystems& group = m_OrderedSystemGroups[updateOrderPriority];
+        UnorderedSystems& group = m_OrderedSystemGroups[updateOrderLevel];
         System* system = new T(m_EventBroker, args...);
         group.Systems[typeid(T).name()] = system;
 

--- a/src/Engine/Collision/CollisionSystem.cpp
+++ b/src/Engine/Collision/CollisionSystem.cpp
@@ -4,8 +4,6 @@
 
 void CollisionSystem::UpdateComponent(World * world, ComponentWrapper & cAABB, double dt)
 {
-    //TODO: Update CollisionSystem system after PlayerSystem.
-
     //Right now, cAABB is a component attached to any entity that should be collideable.
     AABB thisBox;
     if (!Collision::GetEntityBox(world, cAABB, thisBox)) {

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -52,15 +52,17 @@ Game::Game(int argc, char* argv[])
 
     // Create system pipeline
     m_SystemPipeline = new SystemPipeline(m_EventBroker);
-    unsigned int updateOrderPriority = 0;
-    m_SystemPipeline->AddSystem<RaptorCopterSystem>(updateOrderPriority);
-    m_SystemPipeline->AddSystem<PlayerSystem>(updateOrderPriority);
-    m_SystemPipeline->AddSystem<EditorSystem>(updateOrderPriority, m_Renderer);
+
+    //All systems with orderlevel 0 will be updated first.
+    unsigned int updateOrderLevel = 0;
+    m_SystemPipeline->AddSystem<RaptorCopterSystem>(updateOrderLevel);
+    m_SystemPipeline->AddSystem<PlayerSystem>(updateOrderLevel);
+    m_SystemPipeline->AddSystem<EditorSystem>(updateOrderLevel, m_Renderer);
 
     //Collision and TriggerSystem should update after player.
-    ++updateOrderPriority;
-    m_SystemPipeline->AddSystem<CollisionSystem>(updateOrderPriority);
-    m_SystemPipeline->AddSystem<TriggerSystem>(updateOrderPriority);
+    ++updateOrderLevel;
+    m_SystemPipeline->AddSystem<CollisionSystem>(updateOrderLevel);
+    m_SystemPipeline->AddSystem<TriggerSystem>(updateOrderLevel);
 
     m_LastTime = glfwGetTime();
 

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -52,11 +52,15 @@ Game::Game(int argc, char* argv[])
 
     // Create system pipeline
     m_SystemPipeline = new SystemPipeline(m_EventBroker);
-    m_SystemPipeline->AddSystem<RaptorCopterSystem>();
-    m_SystemPipeline->AddSystem<PlayerSystem>();
-    m_SystemPipeline->AddSystem<EditorSystem>(m_Renderer);
-    m_SystemPipeline->AddSystem<CollisionSystem>();
-    m_SystemPipeline->AddSystem<TriggerSystem>();
+    unsigned int updateOrderPriority = 0;
+    m_SystemPipeline->AddSystem<RaptorCopterSystem>(updateOrderPriority);
+    m_SystemPipeline->AddSystem<PlayerSystem>(updateOrderPriority);
+    m_SystemPipeline->AddSystem<EditorSystem>(updateOrderPriority, m_Renderer);
+
+    //Collision and TriggerSystem should update after player.
+    ++updateOrderPriority;
+    m_SystemPipeline->AddSystem<CollisionSystem>(updateOrderPriority);
+    m_SystemPipeline->AddSystem<TriggerSystem>(updateOrderPriority);
 
     m_LastTime = glfwGetTime();
 

--- a/src/Tests/HealthSystemTest.cpp
+++ b/src/Tests/HealthSystemTest.cpp
@@ -47,8 +47,8 @@ GameHealthSystemTest::GameHealthSystemTest()
 
     // Create system pipeline
     m_SystemPipeline = new SystemPipeline(m_EventBroker);
-    m_SystemPipeline->AddSystem<PlayerSystem>();
-    m_SystemPipeline->AddSystem<HealthSystem>();
+    m_SystemPipeline->AddSystem<PlayerSystem>(0);
+    m_SystemPipeline->AddSystem<HealthSystem>(0);
 
     //The Test
     //create entity which has transorm,player,model,health in it. i.e. is a player

--- a/src/Tests/OctTreeTestGameClass.cpp
+++ b/src/Tests/OctTreeTestGameClass.cpp
@@ -45,7 +45,7 @@ Game::Game(int argc, char* argv[]) : someOctTree(AABB(-0.5f*worldSize, 0.5f*worl
     m_World = new HardcodedTestWorld();
 
     m_SystemPipeline = new SystemPipeline(m_EventBroker);
-    m_SystemPipeline->AddSystem<PlayerSystem>();
+    m_SystemPipeline->AddSystem<PlayerSystem>(0);
 
     m_LastTime = glfwGetTime();
 }


### PR DESCRIPTION
The SystemPipeline can now update systems in a specified order.
Eg:

``` c++
//The zero specifies that the raptor and player systems will be updated first.
m_SystemPipeline->AddSystem<RaptorCopterSystem>(0);
m_SystemPipeline->AddSystem<PlayerSystem>(0);
//Then all systems with 1, then 2, etc. You know how numbers work.
m_SystemPipeline->AddSystem<CollisionSystem>(1);
m_SystemPipeline->AddSystem<TriggerSystem>(1);
```

Since the Raptor- and Player Systems have the same update level, they can may update in any order relatively to eachother.
