### PR TITLE
Possible to disable the MemoryPool allocation in Config files.

### DIFF
--- a/resources/DefaultConfig.ini
+++ b/resources/DefaultConfig.ini
@@ -2,7 +2,9 @@
 LogLevel=1
 LoadMap=
 EditorEnabled=false
-
+; if true -> Pool allocation is not used when calling Allocate/Free, just use regular dynamic allocation. 
+; if false -> Use pool allocation.
+DisableMemoryPool=false
 
 [Video]
 Fullscreen=false

--- a/src/Engine/Core/MemoryPool.cpp
+++ b/src/Engine/Core/MemoryPool.cpp
@@ -1,0 +1,5 @@
+#include "Core/MemoryPool.h"
+namespace DisableMemoryPool
+{
+bool Value = false;
+}

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -16,6 +16,7 @@ Game::Game(int argc, char* argv[])
 
     m_Config = ResourceManager::Load<ConfigFile>("Config.ini");
     ResourceManager::UseThreading = m_Config->Get<bool>("Multithreading.ResourceLoading", true);
+    DisableMemoryPool::Value = m_Config->Get<bool>("Debug.DisableMemoryPool", false);
     LOG_LEVEL = static_cast<_LOG_LEVEL>(m_Config->Get<int>("Debug.LogLevel", 1));
 
     // Create the core event broker


### PR DESCRIPTION
Added an option to disable the Pool allocation in Config.ini, in case there is a mess with the MemoryPool.

In the Config.ini file, under [Debug], the flag DisableMemoryPool, was added. Set to true to disable the pool allocation. If unset, it will default to false, that is, the behavior will be the same as before.
