### PR TITLE
Oct tree

### DIFF
--- a/include/Engine/Collision/CollidableOctreeSystem.h
+++ b/include/Engine/Collision/CollidableOctreeSystem.h
@@ -8,7 +8,7 @@
 class CollidableOctreeSystem : public ImpureSystem, public PureSystem
 {
 public:
-    CollidableOctreeSystem(EventBroker* eventBroker, Octree* octree)
+    CollidableOctreeSystem(EventBroker* eventBroker, Octree<AABB>* octree)
         : System(eventBroker)
         , PureSystem("Collidable")
         , m_Octree(octree)
@@ -18,7 +18,7 @@ public:
     virtual void UpdateComponent(World* world, EntityWrapper& entity, ComponentWrapper& component, double dt) override;
 
 private:
-    Octree* m_Octree;
+    Octree<AABB>* m_Octree;
 };
 
 #endif

--- a/include/Engine/Collision/CollisionSystem.h
+++ b/include/Engine/Collision/CollisionSystem.h
@@ -13,7 +13,7 @@
 class CollisionSystem : public PureSystem
 {
 public:
-    CollisionSystem(EventBroker* eventBroker, Octree* octree)
+    CollisionSystem(EventBroker* eventBroker, Octree<AABB>* octree)
         : System(eventBroker)
         , PureSystem("Collidable")
         , m_Octree(octree)
@@ -26,7 +26,7 @@ public:
     virtual void UpdateComponent(World* world, EntityWrapper& entity, ComponentWrapper& component, double dt) override;
 
 private:
-    Octree* m_Octree;
+    Octree<AABB>* m_Octree;
     bool zPress;
 
     EventRelay<CollisionSystem, Events::KeyUp> m_EKeyUp;

--- a/include/Engine/Collision/TriggerSystem.h
+++ b/include/Engine/Collision/TriggerSystem.h
@@ -14,7 +14,7 @@ class AABB;
 class TriggerSystem : public PureSystem
 {
 public:
-    TriggerSystem(EventBroker* eventBroker, Octree* octree)
+    TriggerSystem(EventBroker* eventBroker, Octree<AABB>* octree)
         : System(eventBroker)
         , PureSystem("Trigger")
         , m_Octree(octree)
@@ -27,7 +27,7 @@ public:
     virtual void UpdateComponent(World* world, EntityWrapper& entity, ComponentWrapper& component, double dt) override;
 
 private:
-    Octree* m_Octree;
+    Octree<AABB>* m_Octree;
     std::unordered_map<EntityID, std::unordered_set<EntityID>> m_EntitiesTouchingTrigger;
     std::unordered_map<EntityID, std::unordered_set<EntityID>> m_EntitiesCompletelyInTrigger;
 

--- a/include/Engine/Core/Octree.h
+++ b/include/Engine/Core/Octree.h
@@ -1,19 +1,27 @@
 #ifndef Octree_h__
 #define Octree_h__
 
+#include <type_traits>
+
 #include "../Common.h"
 #include "AABB.h"
 
+//Fwd declarations.
 class Ray;
 
+namespace OctSpace
+{
+struct Output;
+struct ContainedObject;
+struct Child;
+}
+
+//T needs to be AABB, or inherit from AABB.
+//T also needs to have a default constructor.
+template<typename T>
 class Octree
 {
 public:
-    struct Output
-    {
-        float CollideDistance;
-    };
-
     Octree() = delete;
     ~Octree();
     //For the root Octree, [octreeBounds] should be a box containing the entire level.
@@ -25,81 +33,201 @@ public:
     Octree(const Octree&& other) = delete;
     Octree& operator= (const Octree& other) = delete;
     //Add a dynamic object (one that moves around) into the tree.
-    void AddDynamicObject(const AABB& box);
+    void AddDynamicObject(const T& object);
     //Add a static object (that does not move) into the tree.
-    void AddStaticObject(const AABB& box);
-    //Get the boxes that are in the same area as the input [box], the boxes are put in [outBoxes].
-    void BoxesInSameRegion(const AABB& box, std::vector<AABB>& outBoxes);
+    void AddStaticObject(const T& object);
+    //Get the objects that are in the same area as the input [box], the objects are put in [outObjects].
+    //The type Box must be AABB, or inherit from AABB.
+    template<typename Box>
+    void ObjectsInSameRegion(const Box& box, std::vector<T>& outObjects);
     //Empty the tree of all objects, static and dynamic.
     void ClearObjects();
     //Empty the tree of all dynamic objects. Static objects remain in the tree.
     void ClearDynamicObjects();
 
     //Returns true if the ray collides with something in the tree. Result is written to [data].
-    bool RayCollides(const Ray& ray, Output& data);
+    bool RayCollides(const Ray& ray, OctSpace::Output& data);
     //Returns true if the box collides with something in the tree. 
     //On collision with a box, that box is written to [outBoxIntersected].
-    //Note: More efficient than calling BoxesInSameRegion from outside and testing there.
+    //Note: More efficient than calling ObjectsInSameRegion from outside and testing there.
     bool BoxCollides(const AABB& boxToTest, AABB& outBoxIntersected);
 
 private:
-    struct Child;    //Fwd declaration;
-    struct ContainedObject
-    {
-        ContainedObject()
-            : Box(AABB())
-            , Checked(false)
-        {}
-        ContainedObject(AABB box)
-            : Box(box)
-            , Checked(false)
-        {}
-        AABB Box;
-        bool Checked;
-    };
-    Child* m_Root;
-    std::vector<ContainedObject> m_StaticObjects;
-    std::vector<ContainedObject> m_DynamicObjects;
-
-    bool m_UpdatedOnce;
-    unsigned int m_BoxID;
-    glm::vec3 m_PrevPos;
-    glm::quat m_PrevOri;
+    OctSpace::Child* m_Root;
+    std::vector<OctSpace::ContainedObject> m_StaticObjects;
+    std::vector<OctSpace::ContainedObject> m_DynamicObjects;
 
     void falsifyObjectChecks();
-
-    struct Child
-    {
-        ~Child();
-        Child(const AABB& octTreeBounds, 
-            int subDivisions, 
-            std::vector<Octree::ContainedObject>& staticObjects, 
-            std::vector<Octree::ContainedObject>& dynamicObjects);
-        Child(const Child& other) = delete;
-        Child(const Child&& other) = delete;
-        Child& operator= (const Child& other) = delete;
-        void AddDynamicObject(const AABB& box);
-        void AddStaticObject(const AABB& box);
-        void BoxesInSameRegion(const AABB& box, std::vector<AABB>& outBoxes) const;
-        void ClearObjects();
-        void ClearDynamicObjects();
-        bool RayCollides(const Ray& ray, Output& data) const;
-        bool BoxCollides(const AABB& boxToTest, AABB& outBoxIntersected) const;
-
-        Child* m_Children[8];
-        //Indices into the lists in Octree.
-        std::vector<int> m_StaticObjIndices;
-        std::vector<int> m_DynamicObjIndices;
-        AABB m_Box;
-        //Reference to the lists in Octree.
-        std::vector<Octree::ContainedObject>& m_StaticObjectsRef;
-        std::vector<Octree::ContainedObject>& m_DynamicObjectsRef;
-
-        inline bool hasChildren() const;
-        int childIndexContainingPoint(const glm::vec3& point) const;
-        std::vector<int> childIndicesContainingBox(const AABB& box) const;
-    };
 };
 
+namespace OctSpace
+{
+
+struct Output
+{
+    float CollideDistance;
+};
+
+struct ContainedObject
+{
+    ContainedObject()
+        : Box(nullptr)
+        , Checked(false)
+    {}
+    template<typename BoxlikeObject>
+    ContainedObject(const BoxlikeObject& box)
+        : Box(new BoxlikeObject(box))
+        , Checked(false)
+    {}
+    std::unique_ptr<AABB> Box;
+    bool Checked;
+};
+
+struct Child
+{
+    ~Child();
+    Child(const AABB& octTreeBounds,
+        int subDivisions,
+        std::vector<ContainedObject>& staticObjects,
+        std::vector<ContainedObject>& dynamicObjects);
+    Child(const Child& other) = delete;
+    Child(const Child&& other) = delete;
+    Child& operator= (const Child& other) = delete;
+    void AddDynamicObject(const AABB& box);
+    void AddStaticObject(const AABB& box);
+    template<typename T, typename Box>
+    void ObjectsInSameRegion(const Box& box, std::vector<T>& outObjects) const;
+    void ClearObjects();
+    void ClearDynamicObjects();
+    bool RayCollides(const Ray& ray, Output& data) const;
+    bool BoxCollides(const AABB& boxToTest, AABB& outBoxIntersected) const;
+
+    Child* m_Children[8];
+    //Indices into the lists in Octree.
+    std::vector<int> m_StaticObjIndices;
+    std::vector<int> m_DynamicObjIndices;
+    AABB m_Box;
+    //Reference to the lists in Octree.
+    std::vector<ContainedObject>& m_StaticObjectsRef;
+    std::vector<ContainedObject>& m_DynamicObjectsRef;
+
+    inline bool hasChildren() const;
+    int childIndexContainingPoint(const glm::vec3& point) const;
+    std::vector<int> childIndicesContainingBox(const AABB& box) const;
+};
+
+}
+
+template<typename T>
+Octree<T>::Octree(const AABB& octTreeBounds, int subDivisions)
+    : m_Root(new OctSpace::Child(octTreeBounds, subDivisions, m_StaticObjects, m_DynamicObjects))
+{
+    static_assert(std::is_base_of<AABB, T>::value, "template argument type T in Octree must be a subclass of AABB.");
+}
+
+template<typename T>
+Octree<T>::~Octree()
+{
+    delete m_Root;
+}
+
+template<typename T>
+void Octree<T>::AddDynamicObject(const T& object)
+{
+    m_Root->AddDynamicObject(object);
+    m_DynamicObjects.emplace_back(object);
+}
+
+template<typename T>
+void Octree<T>::AddStaticObject(const T& object)
+{
+    m_Root->AddStaticObject(object);
+    m_StaticObjects.emplace_back(object);
+}
+
+template<typename T>
+template<typename Box>
+void Octree<T>::ObjectsInSameRegion(const Box& box, std::vector<T>& outObjects)
+{
+    static_assert(std::is_base_of<AABB, Box>::value, "template argument type Box in Octree<T>::ObjectsInSameRegion must be a subclass of AABB.");
+    falsifyObjectChecks();
+    m_Root->ObjectsInSameRegion(box, outObjects);
+}
+
+template<typename T>
+void Octree<T>::ClearObjects()
+{
+    m_StaticObjects.clear();
+    m_DynamicObjects.clear();
+    m_Root->ClearObjects();
+}
+
+template<typename T>
+void Octree<T>::ClearDynamicObjects()
+{
+    m_DynamicObjects.clear();
+    m_Root->ClearDynamicObjects();
+}
+
+template<typename T>
+bool Octree<T>::RayCollides(const Ray& ray, OctSpace::Output& data)
+{
+    falsifyObjectChecks();
+    data.CollideDistance = -1;
+    return m_Root->RayCollides(ray, data);
+}
+
+template<typename T>
+bool Octree<T>::BoxCollides(const AABB& boxToTest, AABB& outBoxIntersected)
+{
+    falsifyObjectChecks();
+    return m_Root->BoxCollides(boxToTest, outBoxIntersected);
+}
+
+template<typename T>
+void Octree<T>::falsifyObjectChecks()
+{
+    for (auto& obj : m_StaticObjects) {
+        obj.Checked = false;
+    }
+    for (auto& obj : m_DynamicObjects) {
+        obj.Checked = false;
+    }
+}
+
+template<typename T, typename Box>
+void OctSpace::Child::ObjectsInSameRegion(const Box& box, std::vector<T>& outObjects) const
+{
+    if (hasChildren()) {
+        for (auto i : childIndicesContainingBox(box)) {
+            m_Children[i]->ObjectsInSameRegion(box, outObjects);
+        }
+    } else {
+        size_t startIndex = outObjects.size();
+        int numDuplicates = 0;
+        outObjects.resize(outObjects.size() + m_StaticObjIndices.size() + m_DynamicObjIndices.size());
+        for (size_t i = 0; i < m_StaticObjIndices.size(); ++i) {
+            ContainedObject& obj = m_StaticObjectsRef[m_StaticObjIndices[i]];
+            if (obj.Checked) {
+                ++numDuplicates;
+            } else {
+                obj.Checked = true;
+                outObjects[startIndex + i - numDuplicates] = *static_cast<T*>(obj.Box.get());
+            }
+        }
+        for (size_t i = 0; i < m_DynamicObjIndices.size(); ++i) {
+            ContainedObject& obj = m_DynamicObjectsRef[m_DynamicObjIndices[i]];
+            if (obj.Checked) {
+                ++numDuplicates;
+            } else {
+                obj.Checked = true;
+                outObjects[startIndex + i - numDuplicates] = *static_cast<T*>(obj.Box.get());
+            }
+        }
+        for (size_t i = 0; i < numDuplicates; ++i) {
+            outObjects.pop_back();
+        }
+    }
+}
 
 #endif

--- a/include/Game/Game.h
+++ b/include/Game/Game.h
@@ -47,8 +47,8 @@ private:
     InputProxy* m_InputProxy;
 	GUI::Frame* m_FrameStack;
     World* m_World;
-    Octree* m_OctreeCollision;
-    Octree* m_OctreeFrustrumCulling;
+    Octree<AABB>* m_OctreeCollision;
+    Octree<AABB>* m_OctreeFrustrumCulling;
     SystemPipeline* m_SystemPipeline;
     RenderFrame* m_RenderFrame;
     // Network variables

--- a/resources/Schema/Components/Physics.xml
+++ b/resources/Schema/Components/Physics.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <Physics xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="Physics.xsd">
 	<Velocity X="0" Y="0" Z="0"/>
+	<Gravity>true</Gravity>
 </Physics>

--- a/resources/Schema/Components/Physics.xsd
+++ b/resources/Schema/Components/Physics.xsd
@@ -10,6 +10,7 @@
 		<xs:complexType>
 			<xs:all>
 				<xs:element name="Velocity" type="t:Vector" minOccurs="0"/>
+				<xs:element name="Gravity" type="t:bool" minOccurs="0"/>
 			</xs:all>
 		</xs:complexType>
 	</xs:element>

--- a/src/Engine/Collision/CollisionSystem.cpp
+++ b/src/Engine/Collision/CollisionSystem.cpp
@@ -23,7 +23,7 @@ void CollisionSystem::UpdateComponent(World* world, EntityWrapper& entity, Compo
 
     // Collide against octree
     std::vector<AABB> octreeResult;
-    m_Octree->BoxesInSameRegion(*boundingBox, octreeResult);
+    m_Octree->ObjectsInSameRegion(*boundingBox, octreeResult);
     for (auto& boxB : octreeResult) {
         glm::vec3 resolutionVector;
         if (Collision::IsSameBoxProbably(boxA, boxB)) {

--- a/src/Engine/Collision/TriggerSystem.cpp
+++ b/src/Engine/Collision/TriggerSystem.cpp
@@ -34,9 +34,12 @@ void TriggerSystem::UpdateComponent(World* world, EntityWrapper& entity, Compone
             throwLeaveIfWasInTrigger(m_EntitiesCompletelyInTrigger[tId], pId, tId);
         } else {
             //Entity is at least touching the trigger.
-            AABB completelyInsideBox = AABB::FromOriginSize((*triggerBox).Origin(), (*triggerBox).Size() - 2.0f * (*playerBox).Size());
-            if (Collision::AABBVsAABB(completelyInsideBox, *playerBox) &&
-                glm::all(glm::greaterThan((*triggerBox).Size(), (*playerBox).Size()))) {
+            AABB completelyInsideBox;
+            bool playerFitsInTrigger = glm::all(glm::greaterThan((*triggerBox).Size(), (*playerBox).Size()));
+            if (playerFitsInTrigger) {
+                completelyInsideBox = AABB::FromOriginSize((*triggerBox).Origin(), (*triggerBox).Size() - 2.0f * (*playerBox).Size());
+            }
+            if (playerFitsInTrigger && Collision::AABBVsAABB(completelyInsideBox, *playerBox)) {
                 //Entity is completely inside the trigger.
                 //If it was only touching before, it is erased.
                 m_EntitiesTouchingTrigger[tId].erase(pId);

--- a/src/Engine/Core/AABB.cpp
+++ b/src/Engine/Core/AABB.cpp
@@ -15,6 +15,8 @@ AABB::AABB(const glm::vec3& minPos, const glm::vec3& maxPos)
         m_MinCorner.y = glm::min(m_MaxCorner.y, m_MinCorner.y);
         m_MaxCorner.z = glm::max(m_MaxCorner.z, m_MinCorner.z);
         m_MinCorner.z = glm::min(m_MaxCorner.z, m_MinCorner.z);
+        m_Origin = 0.5f * (m_MaxCorner + m_MinCorner);
+        m_HalfSize = 0.5f * (m_MaxCorner - m_MinCorner);
     }
 }
 

--- a/src/Engine/Core/Octree.cpp
+++ b/src/Engine/Core/Octree.cpp
@@ -352,9 +352,13 @@ std::vector<int> Octree::Child::childIndicesContainingBox(const AABB& box) const
         //the dimensions they are responsible for (which octant).
         bits.flip();
         //At this point the bits necessarily have exactly one bit set.
+        //Check the same bit in the minInd as the one set in bits.
+        int setOrUnset = (bits.to_ulong() & minInd);
         for (int c = 0; c < 8; ++c) {
-            //If the child index have the same bit set as the bits, add box to it.
-            if (bits.to_ulong() & c) {
+            //Check the same bit in the child index as the one set in bits.
+            //Enter here if both c and minInd have the bit set, or if neither have it set.
+            //I.e, if they are on the same side (+ or -) in the dimension marked by the bit in bits.
+            if (!((bits.to_ulong() & c) ^ setOrUnset)) {
                 ret.push_back(c);
             }
         }

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -68,8 +68,8 @@ Game::Game(int argc, char* argv[])
     m_Renderer->m_World = m_World;
 
     // Create Octrees
-    m_OctreeCollision = new Octree(AABB(glm::vec3(-100), glm::vec3(100)), 4);
-    m_OctreeFrustrumCulling = new Octree(AABB(glm::vec3(-100), glm::vec3(100)), 4);
+    m_OctreeCollision = new Octree<AABB>(AABB(glm::vec3(-100), glm::vec3(100)), 4);
+    m_OctreeFrustrumCulling = new Octree<AABB>(AABB(glm::vec3(-100), glm::vec3(100)), 4);
     // Create system pipeline
     m_SystemPipeline = new SystemPipeline(m_EventBroker);
 

--- a/src/Game/Systems/PlayerMovementSystem.cpp
+++ b/src/Game/Systems/PlayerMovementSystem.cpp
@@ -9,7 +9,9 @@ void PlayerMovementSystem::UpdateComponent(World* world, EntityWrapper& entity, 
     ComponentWrapper& cPhysics = entity["Physics"];
 
     glm::vec3& velocity = cPhysics["Velocity"];
-    velocity.y -= 9.82 * dt;
+    if (cPhysics["Gravity"]) {
+        velocity.y -= 9.82 * dt;
+    }
 
     glm::vec3& position = cTransform["Position"];
     position += velocity * (float)dt;

--- a/src/Tests/CollisionTest.cpp
+++ b/src/Tests/CollisionTest.cpp
@@ -205,9 +205,9 @@ BOOST_AUTO_TEST_CASE(octTest)
 {
     glm::vec3 mini = glm::vec3(-1, -1, -1);
     glm::vec3 maxi = glm::vec3(1, 1, 1);
-    Octree tree(AABB(mini, maxi), 2);
+    Octree<AABB> tree(AABB(mini, maxi), 2);
     tree.AddDynamicObject(AABB(mini, -0.9f*maxi));
-    Octree::Output data;
+    OctSpace::Output data;
     glm::vec3 origin = 3.0f * mini;
     bool rayIntersected = tree.RayCollides(Ray(origin , mini - origin), data);
     BOOST_CHECK(rayIntersected);

--- a/src/Tests/OctTreeTest.cpp
+++ b/src/Tests/OctTreeTest.cpp
@@ -13,12 +13,12 @@ BOOST_AUTO_TEST_CASE(octSameRegionTest)
 {
     glm::vec3 mini = glm::vec3(-1, -1, -1);
     glm::vec3 maxi = glm::vec3(1, 1, 1);
-    Octree tree(AABB(mini, maxi), 2);
+    Octree<AABB> tree(AABB(mini, maxi), 2);
     AABB firstQuadrant(mini, 0.8f*mini);
     tree.AddStaticObject(firstQuadrant);
     AABB testBox(0.9f*mini, 0.8f*mini);
     std::vector<AABB> region;
-    tree.BoxesInSameRegion(testBox, region);
+    tree.ObjectsInSameRegion(testBox, region);
     BOOST_REQUIRE(region.size() == 1);
     AABB& box = region[0];
     BOOST_CHECK_CLOSE_FRACTION(box.Origin().x, firstQuadrant.Origin().x, 0.00001f);
@@ -40,7 +40,7 @@ const int NUM_FUNCTION_LOOPS = 25;
 const int TESTS = 0;                //10
 
 template<typename Tree>
-void RegionTest(Tree& tree)
+void RegionTestOld(Tree& tree)
 {
     AABB aabb;
     aabb.CreateFromCenter(glm::vec3(rand() % LEVEL_BOUNDS, rand() % LEVEL_BOUNDS, rand() % LEVEL_BOUNDS),
@@ -50,9 +50,19 @@ void RegionTest(Tree& tree)
 }
 
 template<typename Tree>
+void RegionTest(Tree& tree)
+{
+    AABB aabb;
+    aabb.CreateFromCenter(glm::vec3(rand() % LEVEL_BOUNDS, rand() % LEVEL_BOUNDS, rand() % LEVEL_BOUNDS),
+        glm::vec3(rand() % MAXSIZE, rand() % MAXSIZE, rand() % MAXSIZE));
+    std::vector<AABB> outVec;
+    tree.ObjectsInSameRegion(aabb, outVec);
+}
+
+template<typename Tree, typename Output>
 void RayTest(Tree& tree)
 {
-    Tree::Output data;
+    Output data;
     glm::vec3 rayStart = glm::vec3(rand() % LEVEL_BOUNDS, rand() % LEVEL_BOUNDS, rand() % LEVEL_BOUNDS);
     glm::vec3 rayEnd = glm::vec3(rand() % LEVEL_BOUNDS, rand() % LEVEL_BOUNDS, rand() % LEVEL_BOUNDS);
     tree.RayCollides({ rayStart , glm::normalize(rayEnd - rayStart) }, data);
@@ -111,13 +121,13 @@ void TestLoop(TestFunction xTest)
 
 BOOST_AUTO_TEST_CASE(octRegionPerfTestWithDuplicates)
 {
-    TestLoop<Old::OctTree>(RegionTest<Old::OctTree>);
+    TestLoop<Old::OctTree>(RegionTestOld<Old::OctTree>);
     BOOST_CHECK(true);
 }
 
 BOOST_AUTO_TEST_CASE(octRegionPerfTestNoDuplicates)
 {
-    TestLoop<Octree>(RegionTest<Octree>);
+    TestLoop<Octree<AABB>>(RegionTest<Octree<AABB>>);
     BOOST_CHECK(true);
 }
 
@@ -129,19 +139,19 @@ BOOST_AUTO_TEST_CASE(octBoxPerfTestWithDuplicates)
 
 BOOST_AUTO_TEST_CASE(octBoxPerfTestNoDuplicates)
 {
-    TestLoop<Octree>(BoxTest<Octree>);
+    TestLoop<Octree<AABB>>(BoxTest<Octree<AABB>>);
     BOOST_CHECK(true);
 }
 
 BOOST_AUTO_TEST_CASE(octRayPerfTestWithDuplicates)
 {
-    TestLoop<Old::OctTree>(RayTest<Old::OctTree>);
+    TestLoop<Old::OctTree>(RayTest<Old::OctTree, Old::OctTree::Output>);
     BOOST_CHECK(true);
 }
 
 BOOST_AUTO_TEST_CASE(octRayPerfTestNoDuplicates)
 {
-    TestLoop<Octree>(RayTest<Octree>);
+    TestLoop<Octree<AABB>>(RayTest<Octree<AABB>, OctSpace::Output>);
     BOOST_CHECK(true);
 }
 
@@ -153,7 +163,7 @@ BOOST_AUTO_TEST_CASE(octNopPerfTestWithDuplicates)
 
 BOOST_AUTO_TEST_CASE(octNopPerfTestNoDuplicates)
 {
-    TestLoop<Octree>(NopTest<Octree>);
+    TestLoop<Octree<AABB>>(NopTest<Octree<AABB>>);
     BOOST_CHECK(true);
 }
 


### PR DESCRIPTION
Octree should find the right boxes even when querying about a box that exists in 4 children, i.e along the axises.

Also added a bool to disable gravity in Physics component.

edit:
Made Octree into a template class that takes AABB or anything derived from AABB as template argument, then objects of that type can be added into the Octree and extracted from ObjectsInSameRegion() method.
