### PR TITLE
AMD crash fix???????????

### DIFF
--- a/include/Engine/Core/ResourceManager.h
+++ b/include/Engine/Core/ResourceManager.h
@@ -200,13 +200,16 @@ static T* ResourceManager::Load(const std::string& resourceName, Resource* paren
     }
 
     //If resource has already been cached and completely loaded.
-    it = m_ResourceCache.find(cacheKey);
-    if (it != m_ResourceCache.end()) {
-        if (it->second != nullptr) {
-            return static_cast<T*>(it->second);
-        } else {
-            //Don't return null on failure, exception instead.
-            throw Resource::FailedLoadingException();
+    {
+        boost::lock_guard<decltype(m_Mutex)> guard(m_Mutex);
+        it = m_ResourceCache.find(cacheKey);
+        if (it != m_ResourceCache.end()) {
+            if (it->second != nullptr) {
+                return static_cast<T*>(it->second);
+            } else {
+                //Don't return null on failure, exception instead.
+                throw Resource::FailedLoadingException();
+            }
         }
     }
 

--- a/include/Engine/Rendering/DrawColorCorrectionPass.h
+++ b/include/Engine/Rendering/DrawColorCorrectionPass.h
@@ -7,6 +7,7 @@
 #include "ShaderProgram.h"
 //#include "Util/UnorderedMapVec2.h"
 #include "Texture.h"
+#include "imgui/imgui.h"
 
 class DrawColorCorrectionPass
 {
@@ -16,14 +17,13 @@ public:
     void InitializeFrameBuffers();
     void InitializeShaderPrograms();
 
-    void Draw(GLuint sceneTexture, GLuint bloomTexture);
+    void Draw(GLuint sceneTexture, GLuint bloomTexture, GLfloat gamma, GLfloat exposure);
 private:
     const IRenderer* m_Renderer;
 
     ShaderProgram* m_ColorCorrectionProgram;
 
     Model* m_ScreenQuad;
-    GLfloat m_Exposure;
 };
 
 #endif 

--- a/include/Engine/Rendering/RenderQueue.h
+++ b/include/Engine/Rendering/RenderQueue.h
@@ -26,6 +26,7 @@ struct RenderScene
     std::list<std::shared_ptr<RenderJob>> DirectionalLightJobs;
     Rectangle Viewport;
     bool ClearDepth = false;
+    glm::vec4 AmbientColor;
 
 	void Clear()
 	{
@@ -40,6 +41,9 @@ struct RenderScene
 struct RenderFrame
 {
 public:
+    //TODO: Getters
+    GLfloat Gamma = 2.2f;
+    GLfloat Exposure = 1.f;
 
     void Add(RenderScene &scene)
     {

--- a/include/Engine/Rendering/Util/GLError.h
+++ b/include/Engine/Rendering/Util/GLError.h
@@ -9,7 +9,7 @@ inline bool _GLERROR(const char* info, const char* file, const char* func, unsig
 	GLenum error = glGetError();
 	if (error != GL_NO_ERROR)
 	{
-		_LOG(LOG_LEVEL_ERROR, file, func, line, "GL Error: %s, %i, %s", info, error, gluErrorString(error));
+		_LOG(LOG_LEVEL_ERROR, file, func, line, "GL Error: %s\nError code: %i, %s\n", info, error, gluErrorString(error));
 		return true;
 	}
 

--- a/resources/Schema/Components.xsd
+++ b/resources/Schema/Components.xsd
@@ -11,6 +11,7 @@
 	<xs:include schemaLocation="Components/AABB.xsd"/>
 	<xs:include schemaLocation="Components/PointLight.xsd"/>
 	<xs:include schemaLocation="Components/DirectionalLight.xsd"/>
+	<xs:include schemaLocation="Components/SceneLight.xsd"/>
 	<xs:include schemaLocation="Components/Trigger.xsd"/>
 	<xs:include schemaLocation="Components/ExplosionEffect.xsd"/>
 	<xs:include schemaLocation="Components/Health.xsd"/>

--- a/resources/Schema/Components/SceneLight.xml
+++ b/resources/Schema/Components/SceneLight.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<SceneLight xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="SceneLight.xsd">
+	<AmbientColor R="0.2" G="0.2" B="0.2" A="1"/>
+	<Visible>true</Visible>
+	<Gamma>2.2</Gamma>
+	<Exposure>1</Exposure>
+</SceneLight>

--- a/resources/Schema/Components/SceneLight.xsd
+++ b/resources/Schema/Components/SceneLight.xsd
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:t="types">
+	<xs:import schemaLocation="../Types.xsd" namespace="types"/>
+	<xs:element name="SceneLight">
+		<xs:annotation>
+			<xs:documentation>Some settings for the scene lighting</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:all>
+				<xs:element name="AmbientColor" type="t:Color" minOccurs="0">
+					<xs:annotation><xs:documentation>Color of the ambient light</xs:documentation></xs:annotation>
+				</xs:element>
+				<xs:element name="Visible" type="t:bool" minOccurs="0">
+					<xs:annotation><xs:documentation>Wether the ambient light should be applied or not</xs:documentation></xs:annotation>
+				</xs:element>
+				<xs:element name="Gamma" type="t:double" minOccurs="0">
+					<xs:annotation><xs:documentation>Gamma correction for the scene</xs:documentation></xs:annotation>
+				</xs:element>
+				<xs:element name="Exposure" type="t:double" minOccurs="0">
+					<xs:annotation><xs:documentation>The exposure of the camera</xs:documentation></xs:annotation>
+				</xs:element>
+			</xs:all>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/resources/Schema/Entities/AssetPedistal.xml
+++ b/resources/Schema/Entities/AssetPedistal.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<Entity name="AssetBase" xmlns:c="components" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../Types/Entity.xsd">
+
+  <Components>
+    <c:Model>
+      <Resource>Models/Core/UnitCylinder.mesh</Resource>
+      <Color A="1" B="1.56862748" G="1.56862748" R="1.56862748"/>
+    </c:Model>
+    <c:Transform>
+      <Position X="0" Y="-0.231354833" Z="0"/>
+    </c:Transform>
+  </Components>
+
+  <Children>
+    <Entity name="Light">
+      <Components>
+        <c:PointLight/>
+        <c:Transform>
+          <Position X="0" Y="0.663784981" Z="0"/>
+        </c:Transform>
+      </Components>
+      <Children/>
+    </Entity>
+    <Entity name="RotationOrigin">
+      <Components>
+        <c:RaptorCopter>
+          <Speed>0.5</Speed>
+          <Axis X="0" Y="1" Z="0"/>
+        </c:RaptorCopter>
+        <c:Transform>
+          <Orientation X="0" Y="28.7916641" Z="0"/>
+        </c:Transform>
+      </Components>
+      <Children>
+        <Entity name="Asset">
+          <Components>
+            <c:Model>
+              <Resource>Models/AssaultWeaponBlue.mesh</Resource>
+            </c:Model>
+            <c:Transform>
+              <Position X="0" Y="1" Z="0"/>
+              <Orientation X="0.524000049" Y="0" Z="0"/>
+            </c:Transform>
+          </Components>
+          <Children/>
+        </Entity>
+      </Children>
+    </Entity>
+  </Children>
+
+</Entity>

--- a/resources/Schema/Entities/EditorTestWorld.xml
+++ b/resources/Schema/Entities/EditorTestWorld.xml
@@ -2,7 +2,9 @@
 <Entity xmlns:c="components" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../Types/Entity.xsd">
 
   <Components>
-    <c:Transform/>
+    <c:Transform>
+      <Position X="0" Y="-1" Z="0"/>
+    </c:Transform>
   </Components>
 
   <Children>
@@ -18,7 +20,7 @@
       </Components>
       <Children/>
     </Entity>
-    <Entity>
+    <Entity name="Listener">
       <Components>
         <c:Camera/>
         <c:Listener/>
@@ -38,18 +40,27 @@
           <Resource>Models/DirectionalLightWidget.mesh</Resource>
         </c:Model>
         <c:RaptorCopter>
-          <Speed>1.0499999523162842</Speed>
+          <Speed>1</Speed>
           <Axis X="0" Y="1" Z="0"/>
         </c:RaptorCopter>
         <c:Transform>
           <Position X="2.1529963" Y="6.59221172" Z="0.169116676"/>
-          <Orientation X="4.16300011" Y="1422.89319" Z="0"/>
+          <Orientation X="4.16300011" Y="7875.41211" Z="0"/>
         </c:Transform>
       </Components>
       <Children/>
     </Entity>
     <Entity name="AssaultTPose">
       <Components>
+        <c:ExplosionEffect>
+          <ColorByDistance>true</ColorByDistance>
+          <Velocity X="0" Y="0" Z="0.300000012"/>
+          <ExplosionOrigin X="0" Y="1.30000007" Z="0"/>
+          <TimeSinceDeath>5.0498686575577523</TimeSinceDeath>
+          <ExplosionDuration>5</ExplosionDuration>
+          <EndColor A="1" B="1" G="0" R="0"/>
+          <RandomnessScalar>3</RandomnessScalar>
+        </c:ExplosionEffect>
         <c:Model>
           <Resource>Models/Assault.mesh</Resource>
         </c:Model>
@@ -62,11 +73,26 @@
         <Entity name="SecondaryWeapon">
           <Components>
             <c:Model>
-              <Resource>Models/SecondaryWeapon.mesh</Resource>
+              <Resource>Models/AssaultWeaponRed.mesh</Resource>
+              <Transparent>true</Transparent>
             </c:Model>
             <c:Transform>
-              <Position X="-0.546139359" Y="0.853016734" Z="0.177482292"/>
-              <Orientation X="1.47266471" Y="0.524984181" Z="1.243698"/>
+              <Position X="-0.560000002" Y="0.754308224" Z="0.181485131"/>
+              <Orientation X="0.989000022" Y="0" Z="6.10900021"/>
+            </c:Transform>
+          </Components>
+          <Children/>
+        </Entity>
+        <Entity name="SecondaryWeaponRed">
+          <Components>
+            <c:Model>
+              <Resource>Models/DefenderGunRed.mesh</Resource>
+              <Transparent>true</Transparent>
+              <NormalMap>false</NormalMap>
+            </c:Model>
+            <c:Transform>
+              <Position X="0.515922487" Y="0.787437975" Z="0.132855967"/>
+              <Orientation X="0.989000022" Y="0" Z="0"/>
             </c:Transform>
           </Components>
           <Children/>
@@ -85,7 +111,7 @@
           <Components>
             <c:Animation>
               <Name>Run</Name>
-              <Time>0.62051775215976157</Time>
+              <Time>0.17818245776980568</Time>
               <Speed>1</Speed>
             </c:Animation>
             <c:Model>
@@ -101,7 +127,7 @@
           <Components>
             <c:Animation>
               <Name>Walk</Name>
-              <Time>0.28779680073140668</Time>
+              <Time>0.34546191187031372</Time>
               <Speed>1</Speed>
             </c:Animation>
             <c:Model>
@@ -147,70 +173,6 @@
         </c:Transform>
       </Components>
       <Children>
-        <Entity name="NormalSphere">
-          <Components>
-            <c:Model>
-              <Resource>Models/NormalMapSphere.mesh</Resource>
-            </c:Model>
-            <c:Transform>
-              <Position X="1.82700014" Y="0" Z="-0.166000009"/>
-            </c:Transform>
-          </Components>
-          <Children/>
-        </Entity>
-        <Entity name="SpecularSphere">
-          <Components>
-            <c:Model>
-              <Resource>Models/SpecularMapSphere.mesh</Resource>
-            </c:Model>
-            <c:Transform>
-              <Position X="-1.06487739" Y="0" Z="1.52336037"/>
-            </c:Transform>
-          </Components>
-          <Children>
-            <Entity name="Rotationpoint">
-              <Components>
-                <c:RaptorCopter>
-                  <Speed>1</Speed>
-                  <Axis X="0.699999988" Y="1" Z="0.300000012"/>
-                </c:RaptorCopter>
-                <c:Transform>
-                  <Orientation X="404.200684" Y="577.428955" Z="173.228897"/>
-                </c:Transform>
-              </Components>
-              <Children>
-                <Entity name="PointLight">
-                  <Components>
-                    <c:Model>
-                      <Resource>Models/Core/UnitSphere.mesh</Resource>
-                      <Color A="1" B="0" G="3.92156863" R="3.92156863"/>
-                    </c:Model>
-                    <c:PointLight>
-                      <Radius>3</Radius>
-                      <Intensity>1.1399998664855957</Intensity>
-                    </c:PointLight>
-                    <c:Transform>
-                      <Position X="0.600000024" Y="0.5" Z="0"/>
-                      <Scale X="0.100000001" Y="0.100000001" Z="0.100000001"/>
-                    </c:Transform>
-                  </Components>
-                  <Children/>
-                </Entity>
-              </Children>
-            </Entity>
-          </Children>
-        </Entity>
-        <Entity name="GlowMap">
-          <Components>
-            <c:Model>
-              <Resource>Models/IncandescenceMapSphere.mesh</Resource>
-            </c:Model>
-            <c:Transform>
-              <Position X="-1.10000002" Y="0" Z="-1.80000007"/>
-            </c:Transform>
-          </Components>
-          <Children/>
-        </Entity>
         <Entity name="CombinedSpheres">
           <Components>
             <c:Model>
@@ -227,7 +189,7 @@
               <Axis X="1" Y="1" Z="1"/>
             </c:RaptorCopter>
             <c:Transform>
-              <Orientation X="53.9495354" Y="53.9495354" Z="53.9495354"/>
+              <Orientation X="6484.80273" Y="6484.80273" Z="6484.80273"/>
             </c:Transform>
           </Components>
           <Children>
@@ -284,7 +246,93 @@
             </Entity>
           </Children>
         </Entity>
+        <Entity name="SphereRotationOrigin">
+          <Components>
+            <c:RaptorCopter>
+              <Speed>1</Speed>
+              <Axis X="0" Y="1" Z="0"/>
+            </c:RaptorCopter>
+            <c:Transform>
+              <Orientation X="0" Y="6281.02246" Z="0"/>
+            </c:Transform>
+          </Components>
+          <Children>
+            <Entity name="NormalSphere">
+              <Components>
+                <c:Model>
+                  <Resource>Models/NormalMapSphere.mesh</Resource>
+                </c:Model>
+                <c:Transform>
+                  <Position X="1.82700014" Y="0" Z="-0.166000009"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="SpecularSphere">
+              <Components>
+                <c:Model>
+                  <Resource>Models/SpecularMapSphere.mesh</Resource>
+                </c:Model>
+                <c:Transform>
+                  <Position X="-1.06487739" Y="0" Z="1.52336037"/>
+                </c:Transform>
+              </Components>
+              <Children>
+                <Entity name="Rotationpoint">
+                  <Components>
+                    <c:RaptorCopter>
+                      <Speed>1</Speed>
+                      <Axis X="0.699999988" Y="1" Z="0.300000012"/>
+                    </c:RaptorCopter>
+                    <c:Transform>
+                      <Orientation X="4905.44824" Y="7008.50781" Z="2103.03223"/>
+                    </c:Transform>
+                  </Components>
+                  <Children>
+                    <Entity name="PointLight">
+                      <Components>
+                        <c:Model>
+                          <Resource>Models/Core/UnitSphere.mesh</Resource>
+                          <Color A="1" B="0" G="3.92156863" R="3.92156863"/>
+                        </c:Model>
+                        <c:PointLight>
+                          <Radius>3</Radius>
+                          <Intensity>1.1399998664855957</Intensity>
+                        </c:PointLight>
+                        <c:Transform>
+                          <Position X="0.600000024" Y="0.5" Z="0"/>
+                          <Scale X="0.100000001" Y="0.100000001" Z="0.100000001"/>
+                        </c:Transform>
+                      </Components>
+                      <Children/>
+                    </Entity>
+                  </Children>
+                </Entity>
+              </Children>
+            </Entity>
+            <Entity name="GlowMap">
+              <Components>
+                <c:Model>
+                  <Resource>Models/IncandescenceMapSphere.mesh</Resource>
+                </c:Model>
+                <c:Transform>
+                  <Position X="-1.10000002" Y="0" Z="-1.80000007"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+          </Children>
+        </Entity>
       </Children>
+    </Entity>
+    <Entity name="SceneColors">
+      <Components>
+        <c:SceneLight>
+          <Gamma>1.3999999761581421</Gamma>
+        </c:SceneLight>
+        <c:Transform/>
+      </Components>
+      <Children/>
     </Entity>
   </Children>
 

--- a/resources/Schema/Entities/EditorWidgetTranslate.xml
+++ b/resources/Schema/Entities/EditorWidgetTranslate.xml
@@ -84,15 +84,6 @@
       </Components>
       <Children/>
     </Entity>
-    <Entity name="Light">
-      <Components>
-        <c:PointLight/>
-        <c:Transform>
-          <Position X="0.400000006" Y="0.400000006" Z="0.400000006"/>
-        </c:Transform>
-      </Components>
-      <Children/>
-    </Entity>
   </Children>
 
 </Entity>

--- a/resources/Schema/Entities/Player.xml
+++ b/resources/Schema/Entities/Player.xml
@@ -2,12 +2,12 @@
 <Entity name="Player" xmlns:c="components" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../Types/Entity.xsd">
 
   <Components>
-    <c:Health/>
     <c:AABB>
       <Origin X="0" Y="0.772000015" Z="0"/>
       <Size X="1" Y="1.60000002" Z="1"/>
     </c:AABB>
     <c:Collidable/>
+    <c:Health/>
     <c:Physics>
       <Velocity X="2.30999646e-23" Y="0" Z="1.05272533e-23"/>
     </c:Physics>
@@ -20,7 +20,7 @@
       </Team>
     </c:Team>
     <c:Transform>
-      <Position X="8.60201447e-23" Y="0" Z="3.9201616e-23"/>
+      <Position X="9.56501799e-22" Y="-0.471999973" Z="4.35902473e-22"/>
     </c:Transform>
   </Components>
 
@@ -101,12 +101,19 @@
             </Entity>
             <Entity name="Weapon">
               <Components>
+                <c:ExplosionEffect>
+                  <ColorByDistance>true</ColorByDistance>
+                  <Velocity X="0.800000012" Y="0.0379999988" Z="0"/>
+                  <ExplosionDuration>3.7999999523162842</ExplosionDuration>
+                  <EndColor A="0" B="23.5294113" G="11.7647057" R="0"/>
+                  <Randomness>true</Randomness>
+                </c:ExplosionEffect>
                 <c:Model>
-                  <Resource>Models/AssaultWeapon.mesh</Resource>
+                  <Resource>Models/AssaultWeaponRed.mesh</Resource>
                 </c:Model>
                 <c:Transform>
                   <Position X="0.180000007" Y="-0.183000013" Z="0"/>
-                  <Orientation X="0" Y="4.64700031" Z="0"/>
+                  <Orientation X="0" Y="3.08300018" Z="0"/>
                 </c:Transform>
               </Components>
               <Children/>
@@ -141,7 +148,7 @@
       <Components>
         <c:Animation>
           <Name>Hold Pos</Name>
-          <Time>0.73515426169631848</Time>
+          <Time>0.73506627647571587</Time>
           <Speed>1</Speed>
         </c:Animation>
         <c:HiddenForLocalPlayer/>

--- a/resources/Schema/Entities/QualityAssurance.xml
+++ b/resources/Schema/Entities/QualityAssurance.xml
@@ -1,0 +1,1558 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<Entity xmlns:c="components" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../Types/Entity.xsd">
+
+  <Components>
+    <c:Transform>
+      <Position X="0" Y="-1" Z="0"/>
+    </c:Transform>
+  </Components>
+
+  <Children>
+    <Entity name="Ground">
+      <Components>
+        <c:AABB/>
+        <c:Collidable/>
+        <c:Model>
+          <Resource>Models/Core/UnitPlane.mesh</Resource>
+        </c:Model>
+        <c:Transform>
+          <Scale X="100" Y="1" Z="100"/>
+        </c:Transform>
+      </Components>
+      <Children/>
+    </Entity>
+    <Entity name="SoundTestOrigin">
+      <Components>
+        <c:Camera>
+          <FOV>90</FOV>
+        </c:Camera>
+        <c:Listener/>
+        <c:Transform>
+          <Position X="6.86900043" Y="1.30500007" Z="28.6792946"/>
+          <Orientation X="-0.0349078141" Y="0.157154545" Z="-2.60252193e-07"/>
+        </c:Transform>
+      </Components>
+      <Children>
+        <Entity name="rotationPoint">
+          <Components>
+            <c:RaptorCopter>
+              <Speed>1</Speed>
+              <Axis X="0" Y="1" Z="0"/>
+            </c:RaptorCopter>
+            <c:Transform>
+              <Orientation X="0" Y="7364.7876" Z="0"/>
+            </c:Transform>
+          </Components>
+          <Children>
+            <Entity name="SoundEmitter">
+              <Components>
+                <c:SoundEmitter>
+                  <FilePath>Audio/crosscounter.wav</FilePath>
+                  <Loop>true</Loop>
+                </c:SoundEmitter>
+                <c:Transform>
+                  <Position X="0" Y="0" Z="3.9000001"/>
+                </c:Transform>
+              </Components>
+              <Children>
+                <Entity name="SoundEmitterText">
+                  <Components>
+                    <c:Text>
+                      <Content>SoundEmitter</Content>
+                      <Resource>Fonts/DroidSans.ttf,64</Resource>
+                    </c:Text>
+                    <c:Transform>
+                      <Scale X="0.5" Y="0.5" Z="0.5"/>
+                    </c:Transform>
+                  </Components>
+                  <Children/>
+                </Entity>
+                <Entity>
+                  <Components>
+                    <c:Transform/>
+                  </Components>
+                  <Children/>
+                </Entity>
+              </Children>
+            </Entity>
+          </Children>
+        </Entity>
+        <Entity name="ListenerText">
+          <Components>
+            <c:Text>
+              <Content>Sound Test</Content>
+              <Resource>Fonts/DroidSans.ttf,64</Resource>
+            </c:Text>
+            <c:Transform>
+              <Orientation X="0" Y="3.31600022" Z="0"/>
+            </c:Transform>
+          </Components>
+          <Children/>
+        </Entity>
+      </Children>
+    </Entity>
+    <Entity name="DirectionalLight">
+      <Components>
+        <c:DirectionalLight>
+          <Intensity>0.80000001192092896</Intensity>
+        </c:DirectionalLight>
+        <c:Model>
+          <Resource>Models/DirectionalLightWidget.mesh</Resource>
+        </c:Model>
+        <c:RaptorCopter>
+          <Speed>1</Speed>
+          <Axis X="0" Y="1" Z="0"/>
+        </c:RaptorCopter>
+        <c:Transform>
+          <Position X="2.1529963" Y="6.59221172" Z="0.169116676"/>
+          <Orientation X="4.16300011" Y="15381.7266" Z="0"/>
+        </c:Transform>
+      </Components>
+      <Children/>
+    </Entity>
+    <Entity name="AnimationTestOrigin">
+      <Components>
+        <c:Transform>
+          <Position X="-9.21499538" Y="0" Z="8.55711079"/>
+          <Orientation X="0" Y="4.829" Z="0"/>
+        </c:Transform>
+      </Components>
+      <Children>
+        <Entity name="RunAnim">
+          <Components>
+            <c:Animation>
+              <Name>Run</Name>
+              <Time>0.28223692849998105</Time>
+              <Speed>1</Speed>
+            </c:Animation>
+            <c:Model>
+              <Resource>models/AssaultAnimated.mesh</Resource>
+            </c:Model>
+            <c:Transform>
+              <Position X="0.786919653" Y="0" Z="0"/>
+            </c:Transform>
+          </Components>
+          <Children/>
+        </Entity>
+        <Entity name="Walkanim">
+          <Components>
+            <c:Animation>
+              <Name>Walk</Name>
+              <Time>0.44951638260048998</Time>
+              <Speed>1</Speed>
+            </c:Animation>
+            <c:Model>
+              <Resource>models/AssaultAnimated.mesh</Resource>
+            </c:Model>
+            <c:Transform/>
+          </Components>
+          <Children/>
+        </Entity>
+        <Entity name="AnimationText">
+          <Components>
+            <c:Text>
+              <Content>Animation test</Content>
+              <Resource>Fonts/DroidSans.ttf,64</Resource>
+            </c:Text>
+            <c:Transform>
+              <Position X="0" Y="2.4000001" Z="0"/>
+              <Orientation X="0" Y="3.08300018" Z="0"/>
+            </c:Transform>
+          </Components>
+          <Children/>
+        </Entity>
+        <Entity name="AssetBase">
+          <Components>
+            <c:Model>
+              <Resource>Models/Core/UnitCylinder.mesh</Resource>
+              <Color A="1" B="1.56862748" G="1.56862748" R="1.56862748"/>
+            </c:Model>
+            <c:Transform>
+              <Position X="-1.10000002" Y="-0.231354833" Z="0"/>
+            </c:Transform>
+          </Components>
+          <Children>
+            <Entity name="Light">
+              <Components>
+                <c:PointLight/>
+                <c:Transform>
+                  <Position X="0" Y="0.663784981" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="RotationOrigin">
+              <Components>
+                <c:RaptorCopter>
+                  <Speed>0.5</Speed>
+                  <Axis X="0" Y="1" Z="0"/>
+                </c:RaptorCopter>
+                <c:Transform>
+                  <Orientation X="0" Y="2019.28503" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children>
+                <Entity name="Asset">
+                  <Components>
+                    <c:Animation>
+                      <Name>Run</Name>
+                      <Time>0.021047045591223501</Time>
+                      <Speed>1</Speed>
+                    </c:Animation>
+                    <c:Model>
+                      <Resource>Models/AssaultAnimated.mesh</Resource>
+                    </c:Model>
+                    <c:Transform>
+                      <Position X="0" Y="0.5" Z="0"/>
+                    </c:Transform>
+                  </Components>
+                  <Children/>
+                </Entity>
+              </Children>
+            </Entity>
+          </Children>
+        </Entity>
+      </Children>
+    </Entity>
+    <Entity name="SpheresOrigin">
+      <Components>
+        <c:Transform>
+          <Position X="-1.36880863" Y="2.44893074" Z="13.6345663"/>
+        </c:Transform>
+      </Components>
+      <Children>
+        <Entity name="CombinedSpheres">
+          <Components>
+            <c:Model>
+              <Resource>models/NormSpecIncdMapSphere.mesh</Resource>
+            </c:Model>
+            <c:Transform/>
+          </Components>
+          <Children/>
+        </Entity>
+        <Entity name="RotationPoint">
+          <Components>
+            <c:RaptorCopter>
+              <Speed>1</Speed>
+              <Axis X="1" Y="1" Z="1"/>
+            </c:RaptorCopter>
+            <c:Transform>
+              <Orientation X="13996.3721" Y="13996.3721" Z="13996.3721"/>
+            </c:Transform>
+          </Components>
+          <Children>
+            <Entity name="PointLight">
+              <Components>
+                <c:Model>
+                  <Resource>Models/Core/UnitSphere.mesh</Resource>
+                  <Color A="1" B="0" G="3.92156863" R="3.92156863"/>
+                </c:Model>
+                <c:PointLight>
+                  <Radius>3</Radius>
+                  <Intensity>1.1399998664855957</Intensity>
+                </c:PointLight>
+                <c:Transform>
+                  <Position X="-1.70000005" Y="0" Z="0"/>
+                  <Scale X="0.100000001" Y="0.100000001" Z="0.100000001"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="PointLight">
+              <Components>
+                <c:Model>
+                  <Resource>Models/Core/UnitSphere.mesh</Resource>
+                  <Color A="1" B="0" G="3.92156863" R="3.92156863"/>
+                </c:Model>
+                <c:PointLight>
+                  <Radius>5.0100002288818359</Radius>
+                  <Intensity>0.69999998807907104</Intensity>
+                </c:PointLight>
+                <c:Transform>
+                  <Position X="0.900000036" Y="1.10000002" Z="0"/>
+                  <Scale X="0.100000001" Y="0.100000001" Z="0.100000001"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="PointLight">
+              <Components>
+                <c:Model>
+                  <Resource>Models/Core/UnitSphere.mesh</Resource>
+                  <Color A="1" B="0" G="3.92156863" R="3.92156863"/>
+                </c:Model>
+                <c:PointLight>
+                  <Radius>4</Radius>
+                  <Intensity>0.80000001192092896</Intensity>
+                </c:PointLight>
+                <c:Transform>
+                  <Position X="0.400000006" Y="-1" Z="-1.50000012"/>
+                  <Scale X="0.100000001" Y="0.100000001" Z="0.100000001"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+          </Children>
+        </Entity>
+        <Entity name="SphereRotationOrigin">
+          <Components>
+            <c:RaptorCopter>
+              <Speed>1</Speed>
+              <Axis X="0" Y="1" Z="0"/>
+            </c:RaptorCopter>
+            <c:Transform>
+              <Orientation X="0" Y="13793.4053" Z="0"/>
+            </c:Transform>
+          </Components>
+          <Children>
+            <Entity name="NormalSphere">
+              <Components>
+                <c:Model>
+                  <Resource>Models/NormalMapSphere.mesh</Resource>
+                </c:Model>
+                <c:Transform>
+                  <Position X="1.82700014" Y="0" Z="-0.166000009"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="SpecularSphere">
+              <Components>
+                <c:Model>
+                  <Resource>Models/SpecularMapSphere.mesh</Resource>
+                </c:Model>
+                <c:Transform>
+                  <Position X="-1.06487739" Y="0" Z="1.52336037"/>
+                </c:Transform>
+              </Components>
+              <Children>
+                <Entity name="Rotationpoint">
+                  <Components>
+                    <c:RaptorCopter>
+                      <Speed>1</Speed>
+                      <Axis X="0.699999988" Y="1" Z="0.300000012"/>
+                    </c:RaptorCopter>
+                    <c:Transform>
+                      <Orientation X="10188.9443" Y="14517.8643" Z="4350.31738"/>
+                    </c:Transform>
+                  </Components>
+                  <Children>
+                    <Entity name="PointLight">
+                      <Components>
+                        <c:Model>
+                          <Resource>Models/Core/UnitSphere.mesh</Resource>
+                          <Color A="1" B="0" G="3.92156863" R="3.92156863"/>
+                        </c:Model>
+                        <c:PointLight>
+                          <Radius>3</Radius>
+                          <Intensity>1.1399998664855957</Intensity>
+                        </c:PointLight>
+                        <c:Transform>
+                          <Position X="0.600000024" Y="0.5" Z="0"/>
+                          <Scale X="0.100000001" Y="0.100000001" Z="0.100000001"/>
+                        </c:Transform>
+                      </Components>
+                      <Children/>
+                    </Entity>
+                  </Children>
+                </Entity>
+              </Children>
+            </Entity>
+            <Entity name="GlowMap">
+              <Components>
+                <c:Model>
+                  <Resource>Models/IncandescenceMapSphere.mesh</Resource>
+                </c:Model>
+                <c:Transform>
+                  <Position X="-1.10000002" Y="0" Z="-1.80000007"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+          </Children>
+        </Entity>
+        <Entity name="Text">
+          <Components>
+            <c:Text>
+              <Content>TextureMap's Test</Content>
+              <Resource>Fonts/DroidSans.ttf,64</Resource>
+            </c:Text>
+            <c:Transform>
+              <Position X="0" Y="1.60000002" Z="0"/>
+              <Orientation X="0" Y="3.20000005" Z="0"/>
+            </c:Transform>
+          </Components>
+          <Children/>
+        </Entity>
+      </Children>
+    </Entity>
+    <Entity name="SceneColors">
+      <Components>
+        <c:SceneLight>
+          <Gamma>1.3999999761581421</Gamma>
+        </c:SceneLight>
+        <c:Transform/>
+      </Components>
+      <Children/>
+    </Entity>
+    <Entity name="PlayerSpawnOrigin">
+      <Components>
+        <c:Transform>
+          <Position X="2.51321125" Y="0.600000024" Z="-0.134501517"/>
+        </c:Transform>
+      </Components>
+      <Children>
+        <Entity name="SpawnerRedTeam">
+          <Components>
+            <c:PlayerSpawn/>
+            <c:Spawner>
+              <EntityFile>Schema/Entities/Player.xml</EntityFile>
+            </c:Spawner>
+            <c:Team>
+              <Team>
+                <Red/>
+              </Team>
+            </c:Team>
+            <c:Transform>
+              <Position X="0" Y="0" Z="-3"/>
+            </c:Transform>
+          </Components>
+          <Children>
+            <Entity name="SpawnPointRedTeam">
+              <Components>
+                <c:SpawnPoint/>
+                <c:Model>
+                  <Resource>Models/Assault.mesh</Resource>
+                  <Color A="1" B="0" G="0" R="1"/>
+                </c:Model>
+                <c:Transform>
+                  <Position X="1" Y="0" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="SpawnPointRedTeam">
+              <Components>
+                <c:SpawnPoint/>
+                <c:Model>
+                  <Resource>Models/Assault.mesh</Resource>
+                  <Color A="1" B="0" G="0" R="1"/>
+                </c:Model>
+                <c:Transform>
+                  <Position X="-1" Y="0" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="SpawnPointRedTeam">
+              <Components>
+                <c:SpawnPoint/>
+                <c:Model>
+                  <Resource>Models/Assault.mesh</Resource>
+                  <Color A="1" B="0" G="0" R="1"/>
+                </c:Model>
+                <c:Transform>
+                  <Position X="0" Y="0" Z="1"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="SpawnPointRedTeam">
+              <Components>
+                <c:SpawnPoint/>
+                <c:Model>
+                  <Resource>Models/Assault.mesh</Resource>
+                  <Color A="1" B="0" G="0" R="1"/>
+                </c:Model>
+                <c:Transform>
+                  <Position X="0" Y="0" Z="-1"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+          </Children>
+        </Entity>
+        <Entity name="SpawnerBlueTeam">
+          <Components>
+            <c:PlayerSpawn/>
+            <c:Spawner>
+              <EntityFile>Schema/Entities/Player.xml</EntityFile>
+            </c:Spawner>
+            <c:Team>
+              <Team>
+                <Blue/>
+              </Team>
+            </c:Team>
+            <c:Transform>
+              <Position X="0" Y="0" Z="3"/>
+              <Orientation X="0" Y="3.20000005" Z="0"/>
+            </c:Transform>
+          </Components>
+          <Children>
+            <Entity name="SpawnPointBlueTeam">
+              <Components>
+                <c:SpawnPoint/>
+                <c:Model>
+                  <Resource>Models/Assault.mesh</Resource>
+                  <Color A="1" B="1" G="0" R="0"/>
+                </c:Model>
+                <c:Transform>
+                  <Position X="1" Y="0" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="SpawnPointBlueTeam">
+              <Components>
+                <c:SpawnPoint/>
+                <c:Model>
+                  <Resource>Models/Assault.mesh</Resource>
+                  <Color A="1" B="1" G="0" R="0"/>
+                </c:Model>
+                <c:Transform>
+                  <Position X="-1" Y="0" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="SpawnPointBlueTeam">
+              <Components>
+                <c:SpawnPoint/>
+                <c:Model>
+                  <Resource>Models/Assault.mesh</Resource>
+                  <Color A="1" B="1" G="0" R="0"/>
+                </c:Model>
+                <c:Transform>
+                  <Position X="0" Y="0" Z="1"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="SpawnPointBlueTeam">
+              <Components>
+                <c:SpawnPoint/>
+                <c:Model>
+                  <Resource>Models/Assault.mesh</Resource>
+                  <Color A="1" B="1" G="0" R="0"/>
+                </c:Model>
+                <c:Transform>
+                  <Position X="0" Y="0" Z="-1"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+          </Children>
+        </Entity>
+        <Entity name="SpawnText">
+          <Components>
+            <c:Text>
+              <Content>Spawn Test</Content>
+              <Resource>Fonts/DroidSans.ttf,64</Resource>
+            </c:Text>
+            <c:Transform>
+              <Position X="0.200000003" Y="2.5" Z="0"/>
+              <Orientation X="0" Y="4.71200037" Z="0"/>
+            </c:Transform>
+          </Components>
+          <Children/>
+        </Entity>
+      </Children>
+    </Entity>
+    <Entity name="TransparancyTestOriginss">
+      <Components>
+        <c:Transform>
+          <Position X="-5.29043961" Y="0" Z="-14.8755674"/>
+        </c:Transform>
+      </Components>
+      <Children>
+        <Entity name="Cube1">
+          <Components>
+            <c:Model>
+              <Resource>Models/Core/UnitCube.mesh</Resource>
+              <Color A="0.505882382" B="0" G="1" R="0"/>
+              <Transparent>true</Transparent>
+            </c:Model>
+            <c:Transform>
+              <Position X="0" Y="0.5" Z="0"/>
+            </c:Transform>
+          </Components>
+          <Children/>
+        </Entity>
+        <Entity name="Cylinder">
+          <Components>
+            <c:Model>
+              <Resource>Models/Core/UnitCylinder.mesh</Resource>
+              <Color A="0.623529434" B="0" G="0.811764717" R="0.917647064"/>
+              <Transparent>true</Transparent>
+            </c:Model>
+            <c:Transform>
+              <Position X="-0.258742422" Y="0.5" Z="-1.8603574"/>
+              <Orientation X="2.03600001" Y="0" Z="0"/>
+            </c:Transform>
+          </Components>
+          <Children/>
+        </Entity>
+        <Entity name="Raptor">
+          <Components>
+            <c:Model>
+              <Resource>Models/Core/UnitRaptor.mesh</Resource>
+              <Color A="0.396078438" B="1" G="1" R="1"/>
+              <Transparent>true</Transparent>
+            </c:Model>
+            <c:Transform>
+              <Position X="1.64195371" Y="1.37490404" Z="0"/>
+            </c:Transform>
+          </Components>
+          <Children/>
+        </Entity>
+        <Entity name="Assault">
+          <Components>
+            <c:Model>
+              <Resource>Models/Assault.mesh</Resource>
+              <Color A="0.572549045" B="1" G="1" R="0"/>
+              <Transparent>true</Transparent>
+            </c:Model>
+            <c:Transform>
+              <Position X="0" Y="0" Z="-1.4000001"/>
+              <Orientation X="0" Y="0.873000026" Z="0"/>
+            </c:Transform>
+          </Components>
+          <Children/>
+        </Entity>
+        <Entity name="Cube2">
+          <Components>
+            <c:Model>
+              <Resource>Models/Core/UnitCube.mesh</Resource>
+              <Color A="0.36470589" B="1" G="0" R="1"/>
+              <Transparent>true</Transparent>
+            </c:Model>
+            <c:Transform>
+              <Position X="1.16991854" Y="0.5" Z="-1.42708254"/>
+              <Scale X="3.70000029" Y="1" Z="1"/>
+              <Orientation X="1.80400014" Y="3.6650002" Z="4.94500017"/>
+            </c:Transform>
+          </Components>
+          <Children/>
+        </Entity>
+        <Entity name="Text">
+          <Components>
+            <c:Text>
+              <Content>Transparency Test</Content>
+              <Resource>Fonts/DroidSans.ttf,64</Resource>
+            </c:Text>
+            <c:Transform>
+              <Position X="0" Y="3.2192595" Z="0"/>
+              <Orientation X="0" Y="0.407000005" Z="0"/>
+            </c:Transform>
+          </Components>
+          <Children/>
+        </Entity>
+      </Children>
+    </Entity>
+    <Entity name="AssetTestOrigin">
+      <Components>
+        <c:Transform>
+          <Position X="-9.45424175" Y="0" Z="-0.110523224"/>
+        </c:Transform>
+      </Components>
+      <Children>
+        <Entity name="AssetBase">
+          <Components>
+            <c:Model>
+              <Resource>Models/Core/UnitCylinder.mesh</Resource>
+              <Color A="1" B="1.56862748" G="1.56862748" R="1.56862748"/>
+            </c:Model>
+            <c:Transform>
+              <Position X="0" Y="-0.231354833" Z="0"/>
+            </c:Transform>
+          </Components>
+          <Children>
+            <Entity name="Light">
+              <Components>
+                <c:PointLight/>
+                <c:Transform>
+                  <Position X="0" Y="0.663784981" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="RotationOrigin">
+              <Components>
+                <c:RaptorCopter>
+                  <Speed>0.5</Speed>
+                  <Axis X="0" Y="1" Z="0"/>
+                </c:RaptorCopter>
+                <c:Transform>
+                  <Orientation X="0" Y="316.504456" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children>
+                <Entity name="Asset">
+                  <Components>
+                    <c:Model>
+                      <Resource>Models/AssaultWeaponBlue.mesh</Resource>
+                    </c:Model>
+                    <c:Transform>
+                      <Position X="0" Y="1" Z="0"/>
+                      <Orientation X="0.524000049" Y="0" Z="0"/>
+                    </c:Transform>
+                  </Components>
+                  <Children/>
+                </Entity>
+              </Children>
+            </Entity>
+          </Children>
+        </Entity>
+        <Entity name="AssetBase">
+          <Components>
+            <c:Model>
+              <Resource>Models/Core/UnitCylinder.mesh</Resource>
+              <Color A="1" B="1.56862748" G="1.56862748" R="1.56862748"/>
+            </c:Model>
+            <c:Transform>
+              <Position X="0" Y="-0.231354833" Z="1.19180429"/>
+            </c:Transform>
+          </Components>
+          <Children>
+            <Entity name="Light">
+              <Components>
+                <c:PointLight/>
+                <c:Transform>
+                  <Position X="0" Y="0.663784981" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="RotationOrigin">
+              <Components>
+                <c:RaptorCopter>
+                  <Speed>0.5</Speed>
+                  <Axis X="0" Y="1" Z="0"/>
+                </c:RaptorCopter>
+                <c:Transform>
+                  <Orientation X="0" Y="316.504456" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children>
+                <Entity name="Asset">
+                  <Components>
+                    <c:Model>
+                      <Resource>Models/AssaultWeaponRed.mesh</Resource>
+                    </c:Model>
+                    <c:Transform>
+                      <Position X="0" Y="1" Z="0"/>
+                      <Orientation X="0.524000049" Y="0" Z="0"/>
+                    </c:Transform>
+                  </Components>
+                  <Children/>
+                </Entity>
+              </Children>
+            </Entity>
+          </Children>
+        </Entity>
+        <Entity name="AssetText">
+          <Components>
+            <c:Text>
+              <Content>Asset Test</Content>
+              <Resource>Fonts/DroidSans.ttf,64</Resource>
+            </c:Text>
+            <c:Transform>
+              <Position X="0" Y="2.4000001" Z="0"/>
+              <Orientation X="0" Y="1.5710001" Z="0"/>
+            </c:Transform>
+          </Components>
+          <Children/>
+        </Entity>
+        <Entity name="AssetBase">
+          <Components>
+            <c:Model>
+              <Resource>Models/Core/UnitCylinder.mesh</Resource>
+              <Color A="1" B="1.56862748" G="1.56862748" R="1.56862748"/>
+            </c:Model>
+            <c:Transform>
+              <Position X="0" Y="-0.231354833" Z="2.4000001"/>
+            </c:Transform>
+          </Components>
+          <Children>
+            <Entity name="Light">
+              <Components>
+                <c:PointLight/>
+                <c:Transform>
+                  <Position X="0" Y="0.663784981" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="RotationOrigin">
+              <Components>
+                <c:RaptorCopter>
+                  <Speed>0.5</Speed>
+                  <Axis X="0" Y="1" Z="0"/>
+                </c:RaptorCopter>
+                <c:Transform>
+                  <Orientation X="0" Y="316.504456" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children>
+                <Entity name="Asset">
+                  <Components>
+                    <c:Model>
+                      <Resource>Models/SecondaryWeapon.mesh</Resource>
+                    </c:Model>
+                    <c:Transform>
+                      <Position X="0" Y="1" Z="0"/>
+                      <Orientation X="0.640000045" Y="0" Z="0"/>
+                    </c:Transform>
+                  </Components>
+                  <Children/>
+                </Entity>
+              </Children>
+            </Entity>
+          </Children>
+        </Entity>
+        <Entity name="AssetBase">
+          <Components>
+            <c:Model>
+              <Resource>Models/Core/UnitCylinder.mesh</Resource>
+              <Color A="1" B="1.56862748" G="1.56862748" R="1.56862748"/>
+            </c:Model>
+            <c:Transform>
+              <Position X="-2.27346039" Y="-0.231354833" Z="-0.0611162409"/>
+            </c:Transform>
+          </Components>
+          <Children>
+            <Entity name="Light">
+              <Components>
+                <c:PointLight/>
+                <c:Transform>
+                  <Position X="0" Y="0.663784981" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="RotationOrigin">
+              <Components>
+                <c:RaptorCopter>
+                  <Speed>0.5</Speed>
+                  <Axis X="0" Y="1" Z="0"/>
+                </c:RaptorCopter>
+                <c:Transform>
+                  <Orientation X="0" Y="316.504456" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children>
+                <Entity name="Asset">
+                  <Components>
+                    <c:Model>
+                      <Resource>Models/AssualtSoft.mesh</Resource>
+                    </c:Model>
+                    <c:Transform>
+                      <Position X="0" Y="0.5" Z="0"/>
+                    </c:Transform>
+                  </Components>
+                  <Children/>
+                </Entity>
+              </Children>
+            </Entity>
+          </Children>
+        </Entity>
+        <Entity name="AssetBase">
+          <Components>
+            <c:Model>
+              <Resource>Models/Core/UnitCylinder.mesh</Resource>
+              <Color A="1" B="1.56862748" G="1.56862748" R="1.56862748"/>
+            </c:Model>
+            <c:Transform>
+              <Position X="0" Y="-0.231354833" Z="-1.30000007"/>
+            </c:Transform>
+          </Components>
+          <Children>
+            <Entity name="Light">
+              <Components>
+                <c:PointLight/>
+                <c:Transform>
+                  <Position X="0" Y="0.663784981" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="RotationOrigin">
+              <Components>
+                <c:RaptorCopter>
+                  <Speed>0.5</Speed>
+                  <Axis X="0" Y="1" Z="0"/>
+                </c:RaptorCopter>
+                <c:Transform>
+                  <Orientation X="0" Y="316.504456" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children>
+                <Entity name="Asset">
+                  <Components>
+                    <c:Model>
+                      <Resource>Models/DefenderGunBlue.mesh</Resource>
+                    </c:Model>
+                    <c:Transform>
+                      <Position X="0" Y="1" Z="0"/>
+                      <Orientation X="0.524000049" Y="0" Z="0"/>
+                    </c:Transform>
+                  </Components>
+                  <Children/>
+                </Entity>
+              </Children>
+            </Entity>
+          </Children>
+        </Entity>
+        <Entity name="AssetBase">
+          <Components>
+            <c:Model>
+              <Resource>Models/Core/UnitCylinder.mesh</Resource>
+              <Color A="1" B="1.56862748" G="1.56862748" R="1.56862748"/>
+            </c:Model>
+            <c:Transform>
+              <Position X="0" Y="-0.231354833" Z="-2.57585168"/>
+            </c:Transform>
+          </Components>
+          <Children>
+            <Entity name="Light">
+              <Components>
+                <c:PointLight/>
+                <c:Transform>
+                  <Position X="0" Y="0.663784981" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="RotationOrigin">
+              <Components>
+                <c:RaptorCopter>
+                  <Speed>0.5</Speed>
+                  <Axis X="0" Y="1" Z="0"/>
+                </c:RaptorCopter>
+                <c:Transform>
+                  <Orientation X="0" Y="316.504456" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children>
+                <Entity name="Asset">
+                  <Components>
+                    <c:Model>
+                      <Resource>Models/DefenderGunRed.mesh</Resource>
+                    </c:Model>
+                    <c:Transform>
+                      <Position X="0" Y="1" Z="0"/>
+                      <Orientation X="0.524000049" Y="0" Z="0"/>
+                    </c:Transform>
+                  </Components>
+                  <Children/>
+                </Entity>
+              </Children>
+            </Entity>
+          </Children>
+        </Entity>
+        <Entity name="AssetBase">
+          <Components>
+            <c:Model>
+              <Resource>Models/Core/UnitCylinder.mesh</Resource>
+              <Color A="1" B="1.56862748" G="1.56862748" R="1.56862748"/>
+            </c:Model>
+            <c:Transform>
+              <Position X="-2.22662115" Y="-0.231354833" Z="-1.91447401"/>
+            </c:Transform>
+          </Components>
+          <Children>
+            <Entity name="Light">
+              <Components>
+                <c:PointLight/>
+                <c:Transform>
+                  <Position X="0" Y="0.663784981" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="RotationOrigin">
+              <Components>
+                <c:RaptorCopter>
+                  <Speed>0.5</Speed>
+                  <Axis X="0" Y="1" Z="0"/>
+                </c:RaptorCopter>
+                <c:Transform>
+                  <Orientation X="0" Y="316.504456" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children>
+                <Entity name="Asset">
+                  <Components>
+                    <c:Model>
+                      <Resource>Models/Assualt.mesh</Resource>
+                    </c:Model>
+                    <c:Transform>
+                      <Position X="0" Y="0.5" Z="0"/>
+                    </c:Transform>
+                  </Components>
+                  <Children/>
+                </Entity>
+              </Children>
+            </Entity>
+          </Children>
+        </Entity>
+      </Children>
+    </Entity>
+    <Entity name="CapturePointTestOrigin">
+      <Components>
+        <c:Transform>
+          <Position X="12.7591639" Y="0" Z="-7.50489998"/>
+        </c:Transform>
+      </Components>
+      <Children>
+        <Entity name="CapturePointTestText">
+          <Components>
+            <c:Text>
+              <Content>CapturePoint Test</Content>
+              <Resource>Fonts/DroidSans.ttf,64</Resource>
+            </c:Text>
+            <c:Transform>
+              <Position X="0" Y="6.9000001" Z="0"/>
+              <Orientation X="0" Y="4.71200037" Z="0"/>
+            </c:Transform>
+          </Components>
+          <Children/>
+        </Entity>
+        <Entity name="RedTeamHomeCapturePoint">
+          <Components>
+            <c:Model>
+              <Resource>Models/CapturePoint.mesh</Resource>
+            </c:Model>
+            <c:Transform>
+              <Position X="0" Y="0" Z="-30"/>
+            </c:Transform>
+          </Components>
+          <Children>
+            <Entity name="Trigger">
+              <Components>
+                <c:AABB/>
+                <c:CapturePoint>
+                  <HomePointForTeam>
+                    <Red/>
+                  </HomePointForTeam>
+                </c:CapturePoint>
+                <c:Model>
+                  <Resource>Models/Core/UnitCube.mesh</Resource>
+                  <Color A="1" B="0" G="0.200000003" R="1"/>
+                  <Transparent>true</Transparent>
+                </c:Model>
+                <c:Team>
+                  <Team>
+                    <Red/>
+                  </Team>
+                </c:Team>
+                <c:Transform>
+                  <Position X="0" Y="2" Z="0"/>
+                  <Scale X="8" Y="4" Z="8"/>
+                </c:Transform>
+                <c:Trigger/>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="Text">
+              <Components>
+                <c:Text>
+                  <Content>Red team home point</Content>
+                  <Resource>Fonts/DroidSans.ttf,64</Resource>
+                </c:Text>
+                <c:Transform>
+                  <Position X="0" Y="4" Z="0"/>
+                  <Scale X="0.400000006" Y="0.400000006" Z="0.400000006"/>
+                  <Orientation X="0" Y="4.71200037" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+          </Children>
+        </Entity>
+        <Entity name="RedMiddleCapturePoint">
+          <Components>
+            <c:Model>
+              <Resource>Models/CapturePoint.mesh</Resource>
+            </c:Model>
+            <c:Transform>
+              <Position X="0" Y="0" Z="-15"/>
+            </c:Transform>
+          </Components>
+          <Children>
+            <Entity name="Trigger">
+              <Components>
+                <c:AABB/>
+                <c:CapturePoint>
+                  <CapturePointNumber>1</CapturePointNumber>
+                </c:CapturePoint>
+                <c:Model>
+                  <Resource>Models/Core/UnitCube.mesh</Resource>
+                  <Color A="1" B="0" G="1" R="1"/>
+                </c:Model>
+                <c:Team/>
+                <c:Transform>
+                  <Position X="0" Y="2" Z="0"/>
+                  <Scale X="8" Y="4" Z="8"/>
+                </c:Transform>
+                <c:Trigger/>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="Text">
+              <Components>
+                <c:Text>
+                  <Content>RedMiddle Point</Content>
+                  <Resource>Fonts/DroidSans.ttf</Resource>
+                </c:Text>
+                <c:Transform>
+                  <Position X="0" Y="4" Z="0"/>
+                  <Scale X="0.400000006" Y="0.400000006" Z="1"/>
+                  <Orientation X="0" Y="4.71200037" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+          </Children>
+        </Entity>
+        <Entity name="MiddleCapturePoint">
+          <Components>
+            <c:Model>
+              <Resource>Models/CapturePoint.mesh</Resource>
+            </c:Model>
+            <c:Transform/>
+          </Components>
+          <Children>
+            <Entity name="Trigger">
+              <Components>
+                <c:AABB/>
+                <c:CapturePoint>
+                  <CapturePointNumber>2</CapturePointNumber>
+                </c:CapturePoint>
+                <c:Model>
+                  <Resource>Models/Core/UnitCube.mesh</Resource>
+                  <Transparent>true</Transparent>
+                </c:Model>
+                <c:Team/>
+                <c:Transform>
+                  <Position X="0" Y="2" Z="0"/>
+                  <Scale X="8" Y="4" Z="8"/>
+                </c:Transform>
+                <c:Trigger/>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="Text">
+              <Components>
+                <c:Text>
+                  <Content>Middle Point</Content>
+                  <Resource>Fonts/DroidSans.ttf,64</Resource>
+                </c:Text>
+                <c:Transform>
+                  <Position X="0" Y="4" Z="0"/>
+                  <Scale X="0.400000006" Y="0.400000006" Z="0.400000006"/>
+                  <Orientation X="0" Y="4.71200037" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+          </Children>
+        </Entity>
+        <Entity name="BlueMiddleCaapturePoint">
+          <Components>
+            <c:Model>
+              <Resource>Models/CapturePoint.mesh</Resource>
+            </c:Model>
+            <c:Transform>
+              <Position X="0" Y="0" Z="15"/>
+            </c:Transform>
+          </Components>
+          <Children>
+            <Entity name="Trigger">
+              <Components>
+                <c:AABB/>
+                <c:CapturePoint>
+                  <CaptureTimer>-12.033302729641917</CaptureTimer>
+                  <CapturePointNumber>3</CapturePointNumber>
+                </c:CapturePoint>
+                <c:Model>
+                  <Resource>Models/Core/UnitCube.mesh</Resource>
+                  <Color A="1" B="1" G="1" R="0"/>
+                </c:Model>
+                <c:Team/>
+                <c:Transform>
+                  <Position X="0" Y="2" Z="0"/>
+                  <Scale X="8" Y="4" Z="8"/>
+                </c:Transform>
+                <c:Trigger/>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="Text">
+              <Components>
+                <c:Text>
+                  <Content>BlueMiddle Point</Content>
+                  <Resource>Fonts/DroidSans.ttf</Resource>
+                </c:Text>
+                <c:Transform>
+                  <Position X="0" Y="4" Z="0"/>
+                  <Scale X="0.400000006" Y="0.400000006" Z="1"/>
+                  <Orientation X="0" Y="4.71200037" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+          </Children>
+        </Entity>
+        <Entity name="BlueTeamHomeCapturePoint">
+          <Components>
+            <c:Model>
+              <Resource>Models/CapturePoint.mesh</Resource>
+            </c:Model>
+            <c:Transform>
+              <Position X="0" Y="0" Z="30"/>
+            </c:Transform>
+          </Components>
+          <Children>
+            <Entity name="Trigger">
+              <Components>
+                <c:AABB/>
+                <c:CapturePoint>
+                  <HomePointForTeam>
+                    <Blue/>
+                  </HomePointForTeam>
+                  <CapturePointNumber>4</CapturePointNumber>
+                </c:CapturePoint>
+                <c:Model>
+                  <Resource>Models/Core/UnitCube.mesh</Resource>
+                  <Color A="1" B="1" G="0.200000003" R="0"/>
+                  <Transparent>true</Transparent>
+                </c:Model>
+                <c:Team>
+                  <Team>
+                    <Blue/>
+                  </Team>
+                </c:Team>
+                <c:Transform>
+                  <Position X="0" Y="2" Z="0"/>
+                  <Scale X="8" Y="4" Z="8"/>
+                </c:Transform>
+                <c:Trigger/>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="Text">
+              <Components>
+                <c:Text>
+                  <Content>Blue team home point</Content>
+                  <Resource>Fonts/DroidSans.ttf,64</Resource>
+                </c:Text>
+                <c:Transform>
+                  <Position X="0" Y="4" Z="0"/>
+                  <Scale X="0.400000006" Y="0.400000006" Z="0.400000006"/>
+                  <Orientation X="0" Y="4.71200037" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+          </Children>
+        </Entity>
+      </Children>
+    </Entity>
+    <Entity name="CollisionTestOrigin">
+      <Components>
+        <c:Transform>
+          <Position X="50.0696526" Y="0" Z="-0.550000012"/>
+          <Orientation X="0" Y="1.5710001" Z="0"/>
+        </c:Transform>
+      </Components>
+      <Children>
+        <Entity name="CollisionMesh">
+          <Components>
+            <c:AABB>
+              <Size X="50" Y="50" Z="50"/>
+            </c:AABB>
+            <c:Collidable/>
+            <c:Model>
+              <Resource>Models/Test/ObstacleCourse.mesh</Resource>
+            </c:Model>
+            <c:Transform>
+              <Position X="0" Y="0.0199999996" Z="0"/>
+            </c:Transform>
+          </Components>
+          <Children/>
+        </Entity>
+        <Entity name="CollisionText">
+          <Components>
+            <c:Text>
+              <Content>Collision Test</Content>
+              <Resource>Fonts/DroidSans.ttf,64</Resource>
+            </c:Text>
+            <c:Transform>
+              <Position X="0" Y="13.1000004" Z="0"/>
+              <Scale X="2" Y="2" Z="2"/>
+              <Orientation X="0" Y="3.08300018" Z="0"/>
+            </c:Transform>
+          </Components>
+          <Children/>
+        </Entity>
+        <Entity name="WallFront">
+          <Components>
+            <c:AABB/>
+            <c:Collidable/>
+            <c:Model>
+              <Resource>Models/Core/UnitCube.mesh</Resource>
+            </c:Model>
+            <c:Transform>
+              <Position X="6.80000019" Y="4.60000038" Z="23.7000008"/>
+              <Scale X="51.4000015" Y="12.500001" Z="1"/>
+            </c:Transform>
+          </Components>
+          <Children/>
+        </Entity>
+        <Entity name="WellLeft">
+          <Components>
+            <c:AABB/>
+            <c:Collidable/>
+            <c:Model>
+              <Resource>Models/Core/UnitCube.mesh</Resource>
+            </c:Model>
+            <c:Transform>
+              <Position X="32.1000023" Y="4.5999999" Z="0"/>
+              <Scale X="1" Y="12.5" Z="49.0000038"/>
+            </c:Transform>
+          </Components>
+          <Children/>
+        </Entity>
+        <Entity name="WallRight">
+          <Components>
+            <c:AABB/>
+            <c:Collidable/>
+            <c:Model>
+              <Resource>Models/Core/UnitCube.mesh</Resource>
+            </c:Model>
+            <c:Transform>
+              <Position X="-17.8151627" Y="4.5999999" Z="0.000119187171"/>
+              <Scale X="1" Y="12.5" Z="47.5000038"/>
+            </c:Transform>
+          </Components>
+          <Children/>
+        </Entity>
+      </Children>
+    </Entity>
+    <Entity name="DeathEffectTestOrigin">
+      <Components>
+        <c:Transform>
+          <Position X="-15.2719116" Y="0" Z="-13.4612761"/>
+        </c:Transform>
+      </Components>
+      <Children>
+        <Entity name="AssetBase">
+          <Components>
+            <c:Model>
+              <Resource>Models/Core/UnitCylinder.mesh</Resource>
+              <Color A="1" B="1.56862748" G="1.56862748" R="1.56862748"/>
+            </c:Model>
+            <c:Transform>
+              <Position X="0" Y="-0.231354833" Z="0"/>
+            </c:Transform>
+          </Components>
+          <Children>
+            <Entity name="Light">
+              <Components>
+                <c:PointLight/>
+                <c:Transform>
+                  <Position X="0" Y="0.663784981" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="RotationOrigin">
+              <Components>
+                <c:RaptorCopter>
+                  <Speed>0.5</Speed>
+                  <Axis X="0" Y="1" Z="0"/>
+                </c:RaptorCopter>
+                <c:Transform>
+                  <Orientation X="0" Y="850.206848" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children>
+                <Entity name="Asset">
+                  <Components>
+                    <c:ExplosionEffect>
+                      <ColorByDistance>true</ColorByDistance>
+                      <Velocity X="0.800000012" Y="0.0379999988" Z="0"/>
+                      <TimeSinceDeath>0.75008034908941568</TimeSinceDeath>
+                      <ExplosionDuration>3.7999999523162842</ExplosionDuration>
+                      <EndColor A="0" B="23.5294113" G="11.7647057" R="0"/>
+                      <Randomness>true</Randomness>
+                    </c:ExplosionEffect>
+                    <c:Model>
+                      <Resource>Models/AssaultWeaponBlue.mesh</Resource>
+                      <Transparent>true</Transparent>
+                    </c:Model>
+                    <c:Transform>
+                      <Position X="0" Y="1" Z="0"/>
+                      <Orientation X="0.524000049" Y="0" Z="0"/>
+                    </c:Transform>
+                  </Components>
+                  <Children/>
+                </Entity>
+              </Children>
+            </Entity>
+          </Children>
+        </Entity>
+        <Entity name="AssetBase">
+          <Components>
+            <c:Model>
+              <Resource>Models/Core/UnitCylinder.mesh</Resource>
+              <Color A="1" B="1.56862748" G="1.56862748" R="1.56862748"/>
+            </c:Model>
+            <c:Transform>
+              <Position X="0" Y="-0.231354833" Z="1.4000001"/>
+            </c:Transform>
+          </Components>
+          <Children>
+            <Entity name="Light">
+              <Components>
+                <c:PointLight/>
+                <c:Transform>
+                  <Position X="0" Y="0.663784981" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="RotationOrigin">
+              <Components>
+                <c:RaptorCopter>
+                  <Speed>0.5</Speed>
+                  <Axis X="0" Y="1" Z="0"/>
+                </c:RaptorCopter>
+                <c:Transform>
+                  <Orientation X="0" Y="850.206848" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children>
+                <Entity name="Asset">
+                  <Components>
+                    <c:ExplosionEffect>
+                      <Velocity X="0.5" Y="1" Z="0"/>
+                      <ExplosionOrigin X="0" Y="0.900000036" Z="0"/>
+                      <TimeSinceDeath>1.1999860997035228</TimeSinceDeath>
+                    </c:ExplosionEffect>
+                    <c:Model>
+                      <Resource>Models/Assault.mesh</Resource>
+                      <Transparent>true</Transparent>
+                    </c:Model>
+                    <c:Transform>
+                      <Position X="0" Y="0.5" Z="0"/>
+                    </c:Transform>
+                  </Components>
+                  <Children/>
+                </Entity>
+              </Children>
+            </Entity>
+          </Children>
+        </Entity>
+        <Entity name="AssetBase">
+          <Components>
+            <c:Model>
+              <Resource>Models/Core/UnitCylinder.mesh</Resource>
+              <Color A="1" B="1.56862748" G="1.56862748" R="1.56862748"/>
+            </c:Model>
+            <c:Transform>
+              <Position X="0" Y="-0.231354833" Z="-1.4516592"/>
+            </c:Transform>
+          </Components>
+          <Children>
+            <Entity name="Light">
+              <Components>
+                <c:PointLight/>
+                <c:Transform>
+                  <Position X="0" Y="0.663784981" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children/>
+            </Entity>
+            <Entity name="RotationOrigin">
+              <Components>
+                <c:RaptorCopter>
+                  <Speed>0.5</Speed>
+                  <Axis X="0" Y="1" Z="0"/>
+                </c:RaptorCopter>
+                <c:Transform>
+                  <Orientation X="0" Y="850.206848" Z="0"/>
+                </c:Transform>
+              </Components>
+              <Children>
+                <Entity name="Asset">
+                  <Components>
+                    <c:Animation>
+                      <Name>Walk</Name>
+                      <Time>0.23053304095120097</Time>
+                      <Speed>1</Speed>
+                    </c:Animation>
+                    <c:ExplosionEffect>
+                      <ColorByDistance>true</ColorByDistance>
+                      <Velocity X="0.300000012" Y="2" Z="0"/>
+                      <ExplosionOrigin X="0" Y="1.30000007" Z="-0.200000003"/>
+                      <TimeSinceDeath>0.68343188336345406</TimeSinceDeath>
+                      <EndColor A="0" B="0.333333343" G="0.933333337" R="3.92156863"/>
+                      <Randomness>true</Randomness>
+                    </c:ExplosionEffect>
+                    <c:Model>
+                      <Resource>Models/AssaultAnimated.mesh</Resource>
+                      <Transparent>true</Transparent>
+                    </c:Model>
+                    <c:Transform>
+                      <Position X="0" Y="0.5" Z="0"/>
+                    </c:Transform>
+                  </Components>
+                  <Children/>
+                </Entity>
+              </Children>
+            </Entity>
+          </Children>
+        </Entity>
+        <Entity name="Text">
+          <Components>
+            <c:Text>
+              <Content>ExplosionEffect Test</Content>
+              <Resource>Fonts/DroidSans.ttf,64</Resource>
+            </c:Text>
+            <c:Transform>
+              <Position X="0" Y="3.80000019" Z="0"/>
+              <Orientation X="0" Y="1.5710001" Z="0"/>
+            </c:Transform>
+          </Components>
+          <Children/>
+        </Entity>
+      </Children>
+    </Entity>
+    <Entity name="PickingOrigin">
+      <Components>
+        <c:Transform>
+          <Position X="-26.0923824" Y="0" Z="0"/>
+        </c:Transform>
+      </Components>
+      <Children>
+        <Entity name="Text">
+          <Components>
+            <c:Text>
+              <Content>Remember to pick random entities.</Content>
+              <Resource>Fonts/DroidSans.ttf,64</Resource>
+            </c:Text>
+            <c:Transform>
+              <Position X="7.57566977" Y="8.63030624" Z="-0.00154382922"/>
+              <Scale X="2" Y="2" Z="1"/>
+              <Orientation X="0" Y="1.5710001" Z="0"/>
+            </c:Transform>
+          </Components>
+          <Children/>
+        </Entity>
+      </Children>
+    </Entity>
+  </Children>
+
+</Entity>

--- a/resources/Schema/Entities/RayBlue.xml
+++ b/resources/Schema/Entities/RayBlue.xml
@@ -7,7 +7,8 @@
     </c:Lifetime>
     <c:Model>
       <Resource>Models/CylinderBullet.mesh</Resource>
-      <Color A="1" B="39.2156868" G="7.84313726" R="0"/>
+      <Color A="0.156862751" B="39.2156868" G="7.84313726" R="0"/>
+      <Transparent>true</Transparent>
     </c:Model>
     <c:Transform>
       <Scale X="0.0109999999" Y="0.0289999992" Z="100"/>

--- a/resources/Schema/Entities/RayRed.xml
+++ b/resources/Schema/Entities/RayRed.xml
@@ -7,7 +7,8 @@
     </c:Lifetime>
     <c:Model>
       <Resource>Models/CylinderBullet.mesh</Resource>
-      <Color A="1" B="0" G="0.525490224" R="39.2156868"/>
+      <Color A="0.156862751" B="0" G="0.525490224" R="39.2156868"/>
+      <Transparent>true</Transparent>
     </c:Model>
     <c:Transform>
       <Scale X="0.0110000009" Y="0.029000001" Z="100"/>

--- a/resources/Schema/Entities/SoundEmitter.xml
+++ b/resources/Schema/Entities/SoundEmitter.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<Entity name="SoundEmitter" xmlns:c="components" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../Types/Entity.xsd">
+
+  <Components>
+    <c:SoundEmitter/>
+    <c:Transform/>
+  </Components>
+
+  <Children>
+    <Entity name="SoundEmitterText">
+      <Components>
+        <c:Text>
+          <Content>SoundEmitter</Content>
+          <Resource>Fonts/DroidSans.ttf,64</Resource>
+        </c:Text>
+        <c:Transform>
+          <Scale X="0.5" Y="0.5" Z="0.5"/>
+        </c:Transform>
+      </Components>
+      <Children/>
+    </Entity>
+  </Children>
+
+</Entity>

--- a/resources/Schema/Entities/SpawnPointClusterWithModels.xml
+++ b/resources/Schema/Entities/SpawnPointClusterWithModels.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<Entity name="SpawnerRedTeam" xmlns:c="components" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../Types/Entity.xsd">
+
+  <Components>
+    <c:PlayerSpawn/>
+    <c:Spawner>
+      <EntityFile>Schema/Entities/Player.xml</EntityFile>
+    </c:Spawner>
+    <c:Team>
+      <Team>
+        <Red/>
+      </Team>
+    </c:Team>
+    <c:Transform/>
+  </Components>
+
+  <Children>
+    <Entity name="SpawnPointRedTeam">
+      <Components>
+        <c:SpawnPoint/>
+        <c:Model>
+          <Resource>Models/Assault.mesh</Resource>
+        </c:Model>
+        <c:Transform>
+          <Position X="1" Y="0" Z="0"/>
+        </c:Transform>
+      </Components>
+      <Children/>
+    </Entity>
+    <Entity name="SpawnPointRedTeam">
+      <Components>
+        <c:SpawnPoint/>
+        <c:Model>
+          <Resource>Models/Assault.mesh</Resource>
+        </c:Model>
+        <c:Transform>
+          <Position X="-1" Y="0" Z="0"/>
+        </c:Transform>
+      </Components>
+      <Children/>
+    </Entity>
+    <Entity name="SpawnPointRedTeam">
+      <Components>
+        <c:SpawnPoint/>
+        <c:Model>
+          <Resource>Models/Assault.mesh</Resource>
+        </c:Model>
+        <c:Transform>
+          <Position X="0" Y="0" Z="1"/>
+        </c:Transform>
+      </Components>
+      <Children/>
+    </Entity>
+    <Entity name="SpawnPointRedTeam">
+      <Components>
+        <c:SpawnPoint/>
+        <c:Model>
+          <Resource>Models/Assault.mesh</Resource>
+        </c:Model>
+        <c:Transform>
+          <Position X="0" Y="0" Z="-1"/>
+        </c:Transform>
+      </Components>
+      <Children/>
+    </Entity>
+  </Children>
+
+</Entity>

--- a/resources/Schema/Entities/SpawnerWithPlayerModel.xml
+++ b/resources/Schema/Entities/SpawnerWithPlayerModel.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<Entity name="SpawnPointRedTeam" xmlns:c="components" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../Types/Entity.xsd">
+
+  <Components>
+    <c:SpawnPoint/>
+    <c:Model>
+      <Resource>Models/Assault.mesh</Resource>
+    </c:Model>
+    <c:Transform>
+      <Position X="1.31625879" Y="0" Z="0"/>
+    </c:Transform>
+  </Components>
+
+  <Children/>
+
+</Entity>

--- a/resources/Schema/Types/Entity.xsd
+++ b/resources/Schema/Types/Entity.xsd
@@ -31,6 +31,7 @@
 							<xs:element ref="c:PlayerSpawn" minOccurs="0"/>
 							<xs:element ref="c:Team" minOccurs="0"/>
 							<xs:element ref="c:DirectionalLight" minOccurs="0"/>
+							<xs:element ref="c:SceneLight" minOccurs="0"/>
 							<xs:element ref="c:UniformScale" minOccurs="0"/>
 							<xs:element ref="c:EditorWidget" minOccurs="0"/>
 							<xs:element ref="c:Lifetime" minOccurs="0"/>

--- a/resources/Shaders/DrawColorCorrection.frag.glsl
+++ b/resources/Shaders/DrawColorCorrection.frag.glsl
@@ -3,6 +3,7 @@
 layout (binding = 0) uniform sampler2D SceneTexture;
 layout (binding = 1) uniform sampler2D BloomTexture;
 uniform float Exposure;
+uniform float Gamma;
 
 in VertexData{
 	vec2 TextureCoordinate;
@@ -12,7 +13,6 @@ out vec4 fragmentColor;
 
 void main()
 {
-	const float gamma = 2.2;
 	vec4 hdrColor = texture(SceneTexture, Input.TextureCoordinate);
 	vec4 bloomColor = texture(BloomTexture, Input.TextureCoordinate);
 	hdrColor += bloomColor;
@@ -21,7 +21,7 @@ void main()
 	vec3 result = vec3(1.0) - exp(-hdrColor.rgb * Exposure);
 
 	//gamme correction
-	result = pow(result, vec3(1.0 / gamma));
+	result = pow(result, vec3(1.0 / Gamma));
 
 	fragmentColor = vec4(result, 1.0);
 	//fragmentColor = hdrColor;

--- a/resources/Shaders/ExplosionEffect.geom.glsl
+++ b/resources/Shaders/ExplosionEffect.geom.glsl
@@ -17,15 +17,21 @@ uniform bool ExponentialAccelaration;
 in VertexData{
 	vec3 Position;
 	vec3 Normal;
+	vec3 Tangent;
+	vec3 BiTangent;
 	vec2 TextureCoordinate;
 	vec4 ExplosionColor;
+	float ExplosionPercentageElapsed;
 }Input[];
 
 out VertexData{
 	vec3 Position;
 	vec3 Normal;
+	vec3 Tangent;
+	vec3 BiTangent;
 	vec2 TextureCoordinate;
 	vec4 ExplosionColor;
+	float ExplosionPercentageElapsed;
 }Output;
 
 layout(triangles) in;
@@ -114,12 +120,17 @@ void main()
 		{
 			// calculate the max distance (s) the triangle will move
 			float s = (randomVelocity.x * ExplosionDuration) + (0.5 * a * pow(ExplosionDuration, 2));
+			float te = (length(triangleCenter2ExplosionRadius) / s);
 			
-			Output.ExplosionColor = EndColor * (length(triangleCenter2ExplosionRadius) / s);
+			Output.ExplosionColor = EndColor;
+			Output.ExplosionPercentageElapsed = te;
+
 		}
 		else
 		{
-			Output.ExplosionColor = EndColor * timePercetage;
+			Output.ExplosionColor = EndColor;
+			Output.ExplosionPercentageElapsed = timePercetage;
+
 		}
 		
 		// for every vertex on the triangle...
@@ -132,6 +143,8 @@ void main()
 			Output.Normal = Input[i].Normal;
 			Output.Position = Input[i].Position;
 			Output.TextureCoordinate = Input[i].TextureCoordinate;
+			Output.Tangent = Input[i].Tangent;
+			Output.BiTangent = Input[i].BiTangent;
 			
 			// convert to model space for the gravity to always be in -y
 			vec4 ExplodedPositionInModelSpace = M * vec4(ExplodedPosition, 1.0);
@@ -154,11 +167,14 @@ void main()
 		// if explosion color should be affected by distance instead of time...
 		if (ColorByDistance == true)
 		{
-			Output.ExplosionColor = vec4(0.0);
+			Output.ExplosionColor = EndColor;
+			Output.ExplosionPercentageElapsed = 0.0;
 		}
 		else
 		{
-			Output.ExplosionColor = EndColor * timePercetage;
+			Output.ExplosionColor = EndColor;
+			Output.ExplosionPercentageElapsed = timePercetage;
+
 		}
 		
 		// for every vertex on the triangle...
@@ -168,7 +184,9 @@ void main()
 			Output.Normal = Input[i].Normal;
 			Output.Position = Input[i].Position;
 			Output.TextureCoordinate = Input[i].TextureCoordinate;
-			
+			Output.Tangent = Input[i].Tangent;
+			Output.BiTangent = Input[i].BiTangent;
+
 			// no change in position, pass through vertex
 			gl_Position = gl_in[i].gl_Position;
 			EmitVertex();

--- a/resources/Shaders/ForwardPlus.frag.glsl
+++ b/resources/Shaders/ForwardPlus.frag.glsl
@@ -7,12 +7,12 @@ uniform vec4 Color;
 uniform vec4 DiffuseColor;
 uniform vec2 ScreenDimensions;
 uniform vec4 FillColor;
+uniform vec4 AmbientColor;
 uniform float FillPercentage;
 layout (binding = 0) uniform sampler2D DiffuseTexture;
 layout (binding = 1) uniform sampler2D NormalMapTexture;
 layout (binding = 2) uniform sampler2D SpecularMapTexture;
 layout (binding = 3) uniform sampler2D GlowMapTexture;
-
 
 #define TILE_SIZE 16
 
@@ -55,12 +55,11 @@ in VertexData{
 	vec3 BiTangent;
 	vec2 TextureCoordinate;
 	vec4 ExplosionColor;
+	float ExplosionPercentageElapsed;
 }Input;
 
 out vec4 sceneColor;
 out vec4 bloomColor;
-
-vec4 scene_ambient = vec4(0.3,0.3,0.3,1);
 
 struct LightResult {
 	vec4 Diffuse;
@@ -120,6 +119,7 @@ void main()
 	vec4 specularTexel = texture2D(SpecularMapTexture, Input.TextureCoordinate);
 	vec4 position = V * M * vec4(Input.Position, 1.0); 
 	vec4 normal = V * CalcNormalMappedValue(Input.Normal, Input.Tangent, Input.BiTangent, Input.TextureCoordinate, NormalMapTexture);
+	normal = normalize(normal);
 	//vec4 normal = normalize(V  * vec4(Input.Normal, 0.0));
 	vec4 viewVec = normalize(-position); 
 
@@ -128,7 +128,7 @@ void main()
 	tilePos.y = int(gl_FragCoord.y/TILE_SIZE);
 
 	LightResult totalLighting;
-	totalLighting.Diffuse = scene_ambient;
+	totalLighting.Diffuse = vec4(AmbientColor.rgb, 1.0);
 	int currentTile = int(floor(gl_FragCoord.x/TILE_SIZE) + (floor(gl_FragCoord.y/TILE_SIZE) * int(ScreenDimensions.x/TILE_SIZE)));
 
 	int start = int(LightGrids.Data[currentTile].Start);
@@ -150,8 +150,9 @@ void main()
 		totalLighting.Specular += light_result.Specular;
 	}
 
-	
-	vec4 color_result = (DiffuseColor + Input.ExplosionColor) * (totalLighting.Diffuse + (totalLighting.Specular * specularTexel)) * diffuseTexel * Color;
+	vec4 color_result = mix((Color * diffuseTexel * DiffuseColor), Input.ExplosionColor, Input.ExplosionPercentageElapsed);
+	color_result = color_result * (totalLighting.Diffuse + (totalLighting.Specular * specularTexel));
+	//vec4 color_result = (DiffuseColor + Input.ExplosionColor) * (totalLighting.Diffuse + (totalLighting.Specular * specularTexel)) * diffuseTexel * Color;
 	
 
 	float pos = ((P * vec4(Input.Position, 1)).y + 1.0)/2.0;
@@ -160,7 +161,7 @@ void main()
 		color_result += FillColor;
 	}
 	sceneColor = vec4(color_result.xyz, clamp(color_result.a, 0, 1));
-	color_result += glowTexel;
+	color_result += glowTexel*3;
 
 	bloomColor = vec4(clamp(color_result.xyz - 1.0, 0, 100), 1.0);
 

--- a/resources/Shaders/ForwardPlus.vert.glsl
+++ b/resources/Shaders/ForwardPlus.vert.glsl
@@ -20,6 +20,7 @@ out VertexData{
 	vec3 BiTangent;
 	vec2 TextureCoordinate;
 	vec4 ExplosionColor;
+	float ExplosionPercentageElapsed;
 }Output;
 
 void main()
@@ -41,5 +42,6 @@ void main()
 	Output.Normal = vec3(M * vec4(Normal, 0.0));
 	Output.Tangent = vec3(M * vec4(Tangent, 0.0));
  	Output.BiTangent = vec3(M * vec4(BiTangent, 0.0));
-	Output.ExplosionColor = vec4(0.0);
+	Output.ExplosionColor = vec4(1.0);
+	Output.ExplosionPercentageElapsed = 0.0;
 }

--- a/src/Engine/Editor/EditorRenderSystem.cpp
+++ b/src/Engine/Editor/EditorRenderSystem.cpp
@@ -23,6 +23,12 @@ void EditorRenderSystem::Update(double dt)
     scene.Camera = m_EditorCamera;
     scene.Viewport = Rectangle(1920, 1080);
 
+    auto cSceneLight = m_World->GetComponents("SceneLight");
+    if (cSceneLight != nullptr) {
+        //these are hardcoded since they want special light treatment and a component just for widgets is stupid.
+        scene.AmbientColor = glm::vec4(0.8, 0.8, 0.8, 1.0);
+    }
+
     auto models = m_World->GetComponents("Model");
     if (models != nullptr) {
         for (auto& cModel : *models) {
@@ -49,7 +55,7 @@ void EditorRenderSystem::Update(double dt)
             glm::mat4 modelMatrix = Transform::ModelMatrix(entity.ID, entity.World);
             for (auto matGroup : model->MaterialGroups()) {
                 std::shared_ptr<ModelJob> modelJob = std::make_shared<ModelJob>(model, scene.Camera, modelMatrix, matGroup, cModel, entity.World, glm::vec4(0), 0.f);
-                if(cModel["Transparent"]) {
+                if (cModel["Transparent"]) {
                     scene.TransparentObjects.push_back(modelJob);
                 } else {
                     scene.OpaqueObjects.push_back(modelJob);

--- a/src/Engine/Rendering/DrawColorCorrectionPass.cpp
+++ b/src/Engine/Rendering/DrawColorCorrectionPass.cpp
@@ -5,7 +5,8 @@ DrawColorCorrectionPass::DrawColorCorrectionPass(IRenderer* renderer)
     m_Renderer = renderer;
 
     m_ScreenQuad = ResourceManager::Load<Model>("Models/Core/ScreenQuad.mesh");
-    m_Exposure = 0.4; //TODO: Renderer: Fixa så att denna går att ändra på genom komponent eller setting.
+
+    //m_Exposure = 0.4; //TODO: Renderer: Fixa så att denna går att ändra på genom komponent eller setting.
 
     InitializeShaderPrograms();
 }
@@ -19,15 +20,16 @@ void DrawColorCorrectionPass::InitializeShaderPrograms()
     m_ColorCorrectionProgram->Link();
 }
 
-void DrawColorCorrectionPass::Draw(GLuint sceneTexture, GLuint bloomTexture)
+void DrawColorCorrectionPass::Draw(GLuint sceneTexture, GLuint bloomTexture, GLfloat gamma, GLfloat exposure)
 {
     //glBindFramebuffer(GL_FRAMEBUFFER, 0);
     GLERROR("DrawScreenQuadPass::Draw: Pre");
 
     DrawScreenQuadPassState state = DrawScreenQuadPassState();
     m_ColorCorrectionProgram->Bind();
-    glClear(GL_COLOR_BUFFER_BIT);
-    glUniform1f(glGetUniformLocation(m_ColorCorrectionProgram->GetHandle(), "Exposure"), m_Exposure);
+    //glClear(GL_COLOR_BUFFER_BIT);
+    glUniform1f(glGetUniformLocation(m_ColorCorrectionProgram->GetHandle(), "Exposure"), exposure);
+    glUniform1f(glGetUniformLocation(m_ColorCorrectionProgram->GetHandle(), "Gamma"), gamma);
 
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, sceneTexture);

--- a/src/Engine/Rendering/DrawColorCorrectionPass.cpp
+++ b/src/Engine/Rendering/DrawColorCorrectionPass.cpp
@@ -27,7 +27,7 @@ void DrawColorCorrectionPass::Draw(GLuint sceneTexture, GLuint bloomTexture, GLf
 
     DrawScreenQuadPassState state = DrawScreenQuadPassState();
     m_ColorCorrectionProgram->Bind();
-    //glClear(GL_COLOR_BUFFER_BIT);
+    glClear(GL_COLOR_BUFFER_BIT);
     glUniform1f(glGetUniformLocation(m_ColorCorrectionProgram->GetHandle(), "Exposure"), exposure);
     glUniform1f(glGetUniformLocation(m_ColorCorrectionProgram->GetHandle(), "Gamma"), gamma);
 

--- a/src/Engine/Rendering/FrameBuffer.cpp
+++ b/src/Engine/Rendering/FrameBuffer.cpp
@@ -54,13 +54,6 @@ void FrameBuffer::Generate()
         case GL_RENDERBUFFER:
             glFramebufferRenderbuffer(GL_FRAMEBUFFER, (*it)->m_Attachment, (*it)->m_ResourceType, *(*it)->m_ResourceHandle);
             GLERROR("FrameBuffer generate: glFramebufferRenderbuffer");
-            if ( (*it)->m_Attachment != GL_COLOR_ATTACHMENT0 ||
-                (*it)->m_Attachment != GL_COLOR_ATTACHMENT1 ||
-                (*it)->m_Attachment != GL_DEPTH_ATTACHMENT ||
-                (*it)->m_Attachment != GL_STENCIL_ATTACHMENT) //TODO: Viktor: Fixa detta
-            {
-                LOG_ERROR("RenderBuffer Attachment not valid.");
-            }
             break;
         }
         

--- a/src/Engine/Rendering/PickingPass.cpp
+++ b/src/Engine/Rendering/PickingPass.cpp
@@ -75,9 +75,9 @@ void PickingPass::Draw(RenderScene& scene)
                 m_EntityColors[std::make_tuple(pickInfo.Entity, pickInfo.World, pickInfo.Camera)] = glm::ivec2(pickColor[0], pickColor[1]);
                 if (m_ColorCounter[0] > 255) {
                     m_ColorCounter[0] = 0;
-                        m_ColorCounter[1] += 5;
+                    m_ColorCounter[1] += 1;
                 } else {
-                        m_ColorCounter[0] += 50;
+                    m_ColorCounter[0] += 1;
                 }
             }
 
@@ -121,9 +121,9 @@ void PickingPass::Draw(RenderScene& scene)
                 m_EntityColors[std::make_tuple(pickInfo.Entity, pickInfo.World, pickInfo.Camera)] = glm::ivec2(pickColor[0], pickColor[1]);
                 if (m_ColorCounter[0] > 255) {
                     m_ColorCounter[0] = 0;
-                    m_ColorCounter[1] += 5;
+                    m_ColorCounter[1] += 1;
                 } else {
-                    m_ColorCounter[0] += 50;
+                    m_ColorCounter[0] += 1;
                 }
             }
 

--- a/src/Engine/Rendering/RenderSystem.cpp
+++ b/src/Engine/Rendering/RenderSystem.cpp
@@ -240,10 +240,17 @@ void RenderSystem::Update(double dt)
         m_Camera->SetOrientation(Transform::AbsoluteOrientation(m_CurrentCamera));
     }
 
-
     RenderScene scene;
     scene.Camera = m_Camera;
     scene.Viewport = Rectangle(1280, 720);
+
+    auto cSceneLight = m_World->GetComponents("SceneLight");
+    if (cSceneLight != nullptr && cSceneLight->begin() != cSceneLight->end()) {
+        m_RenderFrame->Gamma = (double)(*cSceneLight->begin())["Gamma"];
+        m_RenderFrame->Exposure = (double)(*cSceneLight->begin())["Exposure"];
+        scene.AmbientColor = (glm::vec4)(*cSceneLight->begin())["AmbientColor"];
+    }
+
     fillModels(scene.OpaqueObjects, scene.TransparentObjects);
     fillPointLights(scene.PointLightJobs, m_World);
     fillDirectionalLights(scene.DirectionalLightJobs, m_World);

--- a/src/Engine/Rendering/Renderer.cpp
+++ b/src/Engine/Rendering/Renderer.cpp
@@ -119,8 +119,8 @@ void Renderer::Draw(RenderFrame& frame)
 
     }
     m_DrawBloomPass->Draw(m_DrawFinalPass->BloomTexture());
-    if(m_DebugTextureToDraw == 0) {
-        m_DrawColorCorrectionPass->Draw(m_DrawFinalPass->SceneTexture(), m_DrawBloomPass->GaussianTexture());
+    if (m_DebugTextureToDraw == 0) {
+        m_DrawColorCorrectionPass->Draw(m_DrawFinalPass->SceneTexture(), m_DrawBloomPass->GaussianTexture(), frame.Gamma, frame.Exposure);
     }
     if (m_DebugTextureToDraw == 1) {
         m_DrawScreenQuadPass->Draw(m_DrawFinalPass->SceneTexture());


### PR DESCRIPTION
There seems to be two independent bugs wrecking havoc.

Firstly, the threaded resource management seemed to hit a race condition on one Map::find call. We added a mutex around it which will supposedly prevent the race condition, but we're not sure.

Secondly, the AMD drives seem to stop crashing when adding a "missing" glClear to the color correction pass. This is **NOT** a real fix. The crash suggests underlying memory corruption, but we're hoping to catch it in a more debuggable way if it shows up later.
