### PR TITLE
Small fixes to collision/trigger-boxes, etc.

### DIFF
--- a/include/Engine/Collision/Collision.h
+++ b/include/Engine/Collision/Collision.h
@@ -78,6 +78,8 @@ bool AABBVsAABB(const AABB& a, const AABB& b);
 //Also outputs the minimum translation that box [a] would need in order to resolve collision.
 bool AABBVsAABB(const AABB& a, const AABB& b, glm::vec3& minimumTranslation);
 
+//Attaches an AABB which contains all vertices in the entitys Model.
+bool AttachAABBComponentFromModel(EntityWrapper entity);
 // Calculates an absolute AABB from an entity AABB component
 boost::optional<EntityAABB> EntityAbsoluteAABB(EntityWrapper& entity);
 

--- a/include/Engine/Collision/FillOctreeSystem.h
+++ b/include/Engine/Collision/FillOctreeSystem.h
@@ -6,12 +6,12 @@
 #include "Collision.h"
 #include "EntityAABB.h"
 
-class CollidableOctreeSystem : public ImpureSystem, public PureSystem
+class FillOctreeSystem : public ImpureSystem, public PureSystem
 {
 public:
-    CollidableOctreeSystem(World* world, EventBroker* eventBroker, Octree<EntityAABB>* octree, const std::string& componentType)
+    FillOctreeSystem(World* world, EventBroker* eventBroker, Octree<EntityAABB>* octree, const std::string& fillComponentType)
         : System(world, eventBroker)
-        , PureSystem(componentType)
+        , PureSystem(fillComponentType)
         , m_Octree(octree)
     { }
 

--- a/include/Engine/Core/EntityWrapper.h
+++ b/include/Engine/Core/EntityWrapper.h
@@ -25,6 +25,7 @@ struct EntityWrapper
 
     const std::string Name();
     bool HasComponent(const std::string& componentType);
+    void AttachComponent(const char* componentName);
     EntityWrapper Parent();
     EntityWrapper FirstChildByName(const std::string& name);
     EntityWrapper FirstParentWithComponent(const std::string& componentType);

--- a/resources/Schema/Entities/GameMap.xml
+++ b/resources/Schema/Entities/GameMap.xml
@@ -9,7 +9,8 @@
     <Entity name="Scenemesh">
       <Components>
         <c:AABB>
-          <Size X="150" Y="64" Z="180"/>
+          <Origin X="0.195705414" Y="26.0382366" Z="-0.010017395"/>
+          <Size X="135.414337" Y="68.3848572" Z="180.020035"/>
         </c:AABB>
         <c:Collidable/>
         <c:Model>

--- a/src/Engine/Collision/CollisionSystem.cpp
+++ b/src/Engine/Collision/CollisionSystem.cpp
@@ -20,6 +20,7 @@ void CollisionSystem::UpdateComponent(EntityWrapper& entity, ComponentWrapper& c
     // Collide against octree items
     m_OctreeResult.clear();
     m_Octree->ObjectsInSameRegion(*boundingBox, m_OctreeResult);
+    bool everHitTheGround = false;
     for (auto& boxB : m_OctreeResult) {
         glm::vec3 resolutionVector;
         if (boxA.Entity == boxB.Entity) {
@@ -43,17 +44,24 @@ void CollisionSystem::UpdateComponent(EntityWrapper& entity, ComponentWrapper& c
             if (Collision::AABBvsTriangles(boxA, model->m_Vertices, model->m_Indices, modelMatrix, inOutVelocity, verticalStepHeight, isOnGround, resolutionVector)) {
                 (glm::vec3&)cTransform["Position"] += resolutionVector;
                 cPhysics["Velocity"] = inOutVelocity;
-                (bool)cPhysics["IsOnGround"] = isOnGround;
-            } else {
-                (bool)cPhysics["IsOnGround"] = false;
+                if (isOnGround) {
+                    everHitTheGround = true;
+                    (bool)cPhysics["IsOnGround"] = true;
+                }
             }
         } else if (Collision::AABBVsAABB(boxA, boxB, resolutionVector)) {
             //Enter here if boxB has no Model.
             (glm::vec3&)cTransform["Position"] += resolutionVector;
-            (bool)cPhysics["IsOnGround"] = resolutionVector.y > 0;
-            if ((bool)cPhysics["IsOnGround"]){
+            if (resolutionVector.y > 0) {
+                everHitTheGround = true;
+                (bool)cPhysics["IsOnGround"] = true;
                 ((glm::vec3&)cPhysics["Velocity"]).y = 0.f;
             }
         }
+    }
+
+    //This should apply air friction and such, iff zero models were hit.
+    if (!everHitTheGround) {
+        (bool)cPhysics["IsOnGround"] = false;
     }
 }

--- a/src/Engine/Collision/FillOctreeSystem.cpp
+++ b/src/Engine/Collision/FillOctreeSystem.cpp
@@ -7,12 +7,14 @@ void FillOctreeSystem::Update(double dt)
 
 void FillOctreeSystem::UpdateComponent(EntityWrapper& entity, ComponentWrapper& component, double dt)
 {
-    if (entity.HasComponent("AABB")) {
-        boost::optional<EntityAABB> absoluteAABB = Collision::EntityAbsoluteAABB(entity);
-        if (absoluteAABB) {
-            m_Octree->AddDynamicObject(*absoluteAABB);
+    if (!entity.HasComponent("AABB")) {
+        //Derive AABB from model.
+        if (!Collision::AttachAABBComponentFromModel(entity)) {
+            return;
         }
-    } else if (entity.HasComponent("Model")) {
-        // TODO: Derive AABB from model
+    }
+    boost::optional<EntityAABB> absoluteAABB = Collision::EntityAbsoluteAABB(entity);
+    if (absoluteAABB) {
+        m_Octree->AddDynamicObject(*absoluteAABB);
     }
 }

--- a/src/Engine/Collision/FillOctreeSystem.cpp
+++ b/src/Engine/Collision/FillOctreeSystem.cpp
@@ -1,11 +1,11 @@
-#include "Collision/CollidableOctreeSystem.h"
+#include "Collision/FillOctreeSystem.h"
 
-void CollidableOctreeSystem::Update(double dt)
+void FillOctreeSystem::Update(double dt)
 {
     m_Octree->ClearDynamicObjects();
 }
 
-void CollidableOctreeSystem::UpdateComponent(EntityWrapper& entity, ComponentWrapper& component, double dt)
+void FillOctreeSystem::UpdateComponent(EntityWrapper& entity, ComponentWrapper& component, double dt)
 {
     if (entity.HasComponent("AABB")) {
         boost::optional<EntityAABB> absoluteAABB = Collision::EntityAbsoluteAABB(entity);

--- a/src/Engine/Collision/TriggerSystem.cpp
+++ b/src/Engine/Collision/TriggerSystem.cpp
@@ -6,6 +6,10 @@
 void TriggerSystem::UpdateComponent(EntityWrapper& triggerEntity, ComponentWrapper& cTrigger, double dt)
 {
     // The trigger *should* have a bounding box, or something, to test against so it can be triggered.
+    // If it doesn't, add one as big as the model for now, then size can be modified in editor if necessary.
+    if (!triggerEntity.HasComponent("AABB")) {
+        Collision::AttachAABBComponentFromModel(triggerEntity);
+    }
     boost::optional<EntityAABB> triggerBox = Collision::EntityAbsoluteAABB(triggerEntity);
     if (!triggerBox) {
         return;

--- a/src/Engine/Core/EntityWrapper.cpp
+++ b/src/Engine/Core/EntityWrapper.cpp
@@ -19,7 +19,7 @@ bool EntityWrapper::HasComponent(const std::string& componentName)
 void EntityWrapper::AttachComponent(const char* componentName)
 {
     if (!Valid()) {
-        LOG_WARNING("Could not attach \"%s\" component to #%i, component is not valid.", componentName, ID);
+        LOG_WARNING("Could not attach \"%s\" component to #%i, entity is not valid.", componentName, ID);
         return;
     }
     World->AttachComponent(ID, componentName);

--- a/src/Engine/Core/EntityWrapper.cpp
+++ b/src/Engine/Core/EntityWrapper.cpp
@@ -16,6 +16,15 @@ bool EntityWrapper::HasComponent(const std::string& componentName)
     return World->HasComponent(ID, componentName);
 }
 
+void EntityWrapper::AttachComponent(const char* componentName)
+{
+    if (!Valid()) {
+        LOG_WARNING("Could not attach \"%s\" component to #%i, component is not valid.", componentName, ID);
+        return;
+    }
+    World->AttachComponent(ID, componentName);
+}
+
 EntityWrapper EntityWrapper::Parent()
 {
     if (this->World == nullptr || this->ID == EntityID_Invalid) {

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -1,5 +1,5 @@
 #include "Game.h"
-#include "Collision/CollidableOctreeSystem.h"
+#include "Collision/FillOctreeSystem.h"
 #include "Collision/EntityAABB.h"
 #include "Collision/TriggerSystem.h"
 #include "Collision/CollisionSystem.h"
@@ -93,8 +93,8 @@ Game::Game(int argc, char* argv[])
     m_SystemPipeline->AddSystem<CapturePointSystem>(updateOrderLevel);
     // Populate Octree with collidables
     ++updateOrderLevel;
-    m_SystemPipeline->AddSystem<CollidableOctreeSystem>(updateOrderLevel, m_OctreeCollision, "Collidable");
-    m_SystemPipeline->AddSystem<CollidableOctreeSystem>(updateOrderLevel, m_OctreeTrigger, "Player");
+    m_SystemPipeline->AddSystem<FillOctreeSystem>(updateOrderLevel, m_OctreeCollision, "Collidable");
+    m_SystemPipeline->AddSystem<FillOctreeSystem>(updateOrderLevel, m_OctreeTrigger, "Player");
     m_SystemPipeline->AddSystem<PlayerHUD>(updateOrderLevel);
     m_SystemPipeline->AddSystem<AnimationSystem>(updateOrderLevel);
 

--- a/src/Game/Systems/PlayerMovementSystem.cpp
+++ b/src/Game/Systems/PlayerMovementSystem.cpp
@@ -95,7 +95,7 @@ void PlayerMovementSystem::Update(double dt)
                 } else {
                     controller->SetDoubleJumping(true);
                 }
-                velocity.y += 4.f;
+                velocity.y = 4.f;
             }
 
             if (player.HasComponent("AABB")) {


### PR DESCRIPTION
Small additions, see the commit messages.

Bugfix: Air friction is no longer applied just beacause you are completely missing one collideable, even if you are standing on another.

Enhancement: AABBs are automatically attached when adding Collideable-, Trigger-components,etc. The added box is sized and offset to contain the vertices in the Model component.
