### PR TITLE
World snapshots

### DIFF
--- a/include/Engine/Core/ComponentInfo.h
+++ b/include/Engine/Core/ComponentInfo.h
@@ -2,6 +2,7 @@
 #define ComponentInfo_h__
 
 #include "../Common.h"
+#include <boost/shared_array.hpp>
 
 struct ComponentInfo
 {
@@ -29,7 +30,7 @@ struct ComponentInfo
     std::vector<std::string> FieldsInOrder;
     std::vector<std::string> StringFields;
     unsigned int Stride = 0;
-    std::shared_ptr<char> Defaults = nullptr;
+    boost::shared_array<char> Defaults = nullptr;
 	std::shared_ptr<Meta_t> Meta = nullptr;
 };
 

--- a/include/Engine/Core/ComponentInfo.h
+++ b/include/Engine/Core/ComponentInfo.h
@@ -27,6 +27,7 @@ struct ComponentInfo
 	std::string Name;
     std::unordered_map<std::string, Field_t> Fields;
     std::vector<std::string> FieldsInOrder;
+    std::vector<std::string> StringFields;
     unsigned int Stride = 0;
     std::shared_ptr<char> Defaults = nullptr;
 	std::shared_ptr<Meta_t> Meta = nullptr;

--- a/include/Engine/Core/ComponentPool.h
+++ b/include/Engine/Core/ComponentPool.h
@@ -1,6 +1,7 @@
 #ifndef ComponentPool_h__
 #define ComponentPool_h__
 
+#include <set>
 #include "MemoryPool.h"
 #include "ComponentInfo.h"
 #include "ComponentWrapper.h"
@@ -45,7 +46,8 @@ public:
         : m_ComponentInfo(ci)
         , m_Pool(ci.Meta->Allocation, sizeof(EntityID) + ci.Stride)
     { }
-	ComponentPool(const ComponentPool& other) = delete;
+    ~ComponentPool();
+	ComponentPool(const ComponentPool& other);
 	ComponentPool(const ComponentPool&& other) = delete;
 
     const ::ComponentInfo& ComponentInfo() const { return m_ComponentInfo; }

--- a/include/Engine/Core/MemoryPool.h
+++ b/include/Engine/Core/MemoryPool.h
@@ -66,9 +66,24 @@ public:
 		, m_LowestAllocatedSlot(m_NumSlots)
 	{ }
 
-	//We may get problems with memory being released 
-	//prematurely, etc. if we allow copies.
-	MemoryPool(const MemoryPool<T>& other) = delete;
+    MemoryPool(const MemoryPool<T>& other)
+		: m_StartAddress(new char[other.m_NumSlots*other.m_Stride])
+		, m_SlotIsAllocated(other.m_NumSlots, false)
+		, m_NumSlots(other.m_NumSlots)
+		, m_Stride(other.m_Stride)
+		, m_NumAllocatedSlots(0)
+		, m_CurrentAllocSlot(0)
+		, m_LowestAllocatedSlot(m_NumSlots)
+    {
+        // Copy statically allocated pool
+        memcpy(m_StartAddress, other.m_StartAddress, m_NumSlots*m_Stride);
+        // Copy dynamically allocated memory
+        for (char* otherAddr : other.m_ExtraMemory) {
+            char* addr = (char*)malloc(m_Stride);
+            memcpy(addr, otherAddr, m_Stride);
+            m_ExtraMemory.push_back(addr);
+        }
+    }
 	MemoryPool(const MemoryPool<T>&& other) = delete;
 
 	//Free all memory that has been allocated.

--- a/include/Engine/Core/MemoryPool.h
+++ b/include/Engine/Core/MemoryPool.h
@@ -68,12 +68,13 @@ public:
 
     MemoryPool(const MemoryPool<T>& other)
 		: m_StartAddress(new char[other.m_NumSlots*other.m_Stride])
-		, m_SlotIsAllocated(other.m_NumSlots, false)
+		, m_SlotIsAllocated(other.m_SlotIsAllocated)
+        , m_ExtraMemory()
 		, m_NumSlots(other.m_NumSlots)
+		, m_LowestAllocatedSlot(other.m_LowestAllocatedSlot)
+		, m_NumAllocatedSlots(other.m_NumAllocatedSlots)
 		, m_Stride(other.m_Stride)
-		, m_NumAllocatedSlots(0)
-		, m_CurrentAllocSlot(0)
-		, m_LowestAllocatedSlot(m_NumSlots)
+		, m_CurrentAllocSlot(other.m_CurrentAllocSlot)
     {
         // Copy statically allocated pool
         memcpy(m_StartAddress, other.m_StartAddress, m_NumSlots*m_Stride);
@@ -93,8 +94,9 @@ public:
 			delete[] m_StartAddress;
 			m_StartAddress = nullptr;
 		}
-		for (char* addr : m_ExtraMemory)
-			free(addr);
+        for (char* addr : m_ExtraMemory) {
+            free(addr);
+        }
 		m_ExtraMemory.clear();
 	}
 

--- a/include/Engine/Core/Util/Any.h
+++ b/include/Engine/Core/Util/Any.h
@@ -2,6 +2,7 @@
 #define Util_Any_h__
 
 #include <memory>
+#include <boost/shared_array.hpp>
 
 struct Any
 {
@@ -10,7 +11,7 @@ struct Any
     template <typename T>
     Any(const T& value)
     {
-        Data = std::shared_ptr<char>(new char[sizeof(T)]);
+        Data = boost::shared_array<char>(new char[sizeof(T)]);
         Size = sizeof(T);
         memcpy(Data.get(), &value, Size);
     }
@@ -18,7 +19,7 @@ struct Any
     template <typename T>
     Any(T&& value)
     {
-        Data = std::shared_ptr<char>(new char[sizeof(T)]);
+        Data = boost::shared_array<char>(new char[sizeof(T)]);
         Size = sizeof(T);
         memcpy(Data.get(), &value, Size);
     }
@@ -35,7 +36,7 @@ struct Any
         return Any(value);
     }
 
-    std::shared_ptr<char> Data = nullptr;
+    boost::shared_array<char> Data = nullptr;
     std::size_t Size = 0;
 };
 

--- a/include/Engine/Core/World.h
+++ b/include/Engine/Core/World.h
@@ -15,6 +15,7 @@ public:
         : m_EventBroker(eventBroker)
     { }
     ~World();
+    World(const World& other);
 
     // Create empty entity
     EntityID CreateEntity(EntityID parent = 0);

--- a/src/Engine/Core/EntityFilePreprocessor.cpp
+++ b/src/Engine/Core/EntityFilePreprocessor.cpp
@@ -185,6 +185,9 @@ void EntityFilePreprocessor::parseComponentInfo()
             field.Offset = fieldOffset;
             field.Stride = stride;
             compInfo.FieldsInOrder.push_back(name);
+            if (field.Type == "string") {
+                compInfo.StringFields.push_back(name);
+            }
             fieldOffset += stride;
         }
 

--- a/src/Engine/Core/EntityFilePreprocessor.cpp
+++ b/src/Engine/Core/EntityFilePreprocessor.cpp
@@ -204,7 +204,7 @@ void EntityFilePreprocessor::parseDefaults()
 
     for (auto& ci : m_ComponentInfo) {
         // Allocate memory for default values
-        ci.second.Defaults = std::shared_ptr<char>(new char[ci.second.Stride]);
+        ci.second.Defaults = boost::shared_array<char>(new char[ci.second.Stride], std::bind(&ComponentWrapper::Destroy, ci.second, std::placeholders::_1));
         memset(ci.second.Defaults.get(), 0, ci.second.Stride);
 
         std::string componentName = ci.first;

--- a/src/Engine/Core/World.cpp
+++ b/src/Engine/Core/World.cpp
@@ -11,14 +11,18 @@ World::~World()
 
 World::World(const World& other)
     : m_EventBroker(other.m_EventBroker)
+    , m_CurrentEntityID(other.m_CurrentEntityID)
+    , m_EntityParents(other.m_EntityParents)
+    , m_EntityChildren(other.m_EntityChildren)
+    , m_EntityNames(other.m_EntityNames)
 {
     // Deep copy component pools
-    for (auto& kv : m_ComponentPools) {
+    for (auto& kv : other.m_ComponentPools) {
         m_ComponentPools[kv.first] = new ComponentPool(*kv.second);
     }
 }
 
-EntityID World::CreateEntity(EntityID parent /*= 0*/)
+EntityID World::CreateEntity(EntityID parent /*= EntityID_Invalid*/)
 {
     EntityID newEntity = generateEntityID();
     if (newEntity == parent) {
@@ -53,11 +57,8 @@ ComponentWrapper World::AttachComponent(EntityID entity, const std::string& comp
     ComponentPool* pool = m_ComponentPools.at(componentType);
     const ComponentInfo& ci = pool->ComponentInfo();
 
-    // Allocate space for the component
+    // Allocate component with default values
     ComponentWrapper c = pool->Allocate(entity);
-    // Write default values
-    memcpy(c.Data, ci.Defaults.get(), ci.Stride);
-    ComponentWrapper::SolidifyStrings(c);
 
     return c;
 }

--- a/src/Engine/Core/World.cpp
+++ b/src/Engine/Core/World.cpp
@@ -9,6 +9,15 @@ World::~World()
     }
 }
 
+World::World(const World& other)
+    : m_EventBroker(other.m_EventBroker)
+{
+    // Deep copy component pools
+    for (auto& kv : m_ComponentPools) {
+        m_ComponentPools[kv.first] = new ComponentPool(*kv.second);
+    }
+}
+
 EntityID World::CreateEntity(EntityID parent /*= 0*/)
 {
     EntityID newEntity = generateEntityID();

--- a/src/Engine/Core/World.cpp
+++ b/src/Engine/Core/World.cpp
@@ -48,6 +48,7 @@ ComponentWrapper World::AttachComponent(EntityID entity, const std::string& comp
     ComponentWrapper c = pool->Allocate(entity);
     // Write default values
     memcpy(c.Data, ci.Defaults.get(), ci.Stride);
+    ComponentWrapper::SolidifyStrings(c);
 
     return c;
 }


### PR DESCRIPTION
Implemented copy constructors for World, ComponentPool and MemoryPool to enable World to be snapshotted. Component field string handling is now properly making copies of the strings instead of relying on undefined behaviour, and frees them properly as well.
