### PR TITLE
CapturePointSystem fix, DamageIndicatorSystem fix

### DIFF
--- a/include/Game/Systems/DamageIndicatorSystem.h
+++ b/include/Game/Systems/DamageIndicatorSystem.h
@@ -14,6 +14,7 @@
 #include <glm/gtx/vector_angle.hpp>
 
 #include "Rendering/Util/CommonFunctions.h"
+//#define INDICATOR_TEST
 
 class DamageIndicatorSystem : public ImpureSystem
 {
@@ -40,8 +41,9 @@ private:
     float CalculateAngle(EntityWrapper player, glm::vec3 enemyPos);
 
     //for tests
-    int m_TestVar = 0;
-    bool m_Testing = false;
+#ifdef INDICATOR_TEST
     glm::vec3 DamageIndicatorTest(EntityWrapper player);
+    int m_TestVar = 0;
+#endif
 };
 #endif

--- a/include/Game/Systems/DamageIndicatorSystem.h
+++ b/include/Game/Systems/DamageIndicatorSystem.h
@@ -15,10 +15,11 @@
 
 #include "Rendering/Util/CommonFunctions.h"
 
-class DamageIndicatorSystem : public System
+class DamageIndicatorSystem : public ImpureSystem
 {
 public:
     DamageIndicatorSystem(SystemParams params);
+    virtual void Update(double dt) override;
 
 private:
     EventRelay<DamageIndicatorSystem, Events::PlayerDamage> m_EPlayerDamage;
@@ -28,6 +29,19 @@ private:
     bool OnSetCamera(const Events::SetCamera& e);
 
     EntityID m_CurrentCamera = -1;
+    struct DamageIndicatorStruct {
+        EntityWrapper spriteEntity;
+        glm::vec3 enemyPosition;
+        DamageIndicatorStruct(EntityWrapper sprite, glm::vec3 pos)
+            : spriteEntity(sprite)
+            , enemyPosition(pos) {}
+    };
+    std::vector<DamageIndicatorStruct> updateDamageIndicatorVector;
+    float CalculateAngle(EntityWrapper player, glm::vec3 enemyPos);
 
+    //for tests
+    int m_TestVar = 0;
+    bool m_Testing = false;
+    glm::vec3 DamageIndicatorTest(EntityWrapper player);
 };
 #endif

--- a/src/Game/Systems/CapturePointSystem.cpp
+++ b/src/Game/Systems/CapturePointSystem.cpp
@@ -16,9 +16,6 @@ CapturePointSystem::CapturePointSystem(SystemParams params)
 //NOTE: needs to run each frame, since we're possibly modifying the captureTimer for the capturePoints by dt
 void CapturePointSystem::UpdateComponent(EntityWrapper& capturePointEntity, ComponentWrapper& cCapturePoint, double dt)
 {
-    //if (!IsClient) {
-    //    return;
-    //}
     if (m_WinnerWasFound) {
         return;
     }

--- a/src/Game/Systems/CapturePointSystem.cpp
+++ b/src/Game/Systems/CapturePointSystem.cpp
@@ -1,32 +1,37 @@
 #include "Systems/CapturePointSystem.h"
 #include <algorithm>
 
-CapturePointSystem::CapturePointSystem(SystemParams params) 
+CapturePointSystem::CapturePointSystem(SystemParams params)
     : System(params)
     , PureSystem("CapturePoint")
 {
     //subscribe/listenTo playerdamage,healthpickup events (using the eventBroker)
-    if (IsClient) {
-        EVENT_SUBSCRIBE_MEMBER(m_ETriggerTouch, &CapturePointSystem::OnTriggerTouch);
-        EVENT_SUBSCRIBE_MEMBER(m_ETriggerLeave, &CapturePointSystem::OnTriggerLeave);
-        EVENT_SUBSCRIBE_MEMBER(m_ECaptured, &CapturePointSystem::OnCaptured);
-    }
+    EVENT_SUBSCRIBE_MEMBER(m_ETriggerTouch, &CapturePointSystem::OnTriggerTouch);
+    EVENT_SUBSCRIBE_MEMBER(m_ETriggerLeave, &CapturePointSystem::OnTriggerLeave);
+    EVENT_SUBSCRIBE_MEMBER(m_ECaptured, &CapturePointSystem::OnCaptured);
+
 }
 
 //here all capturepoints will update their component
 //NOTE: needs to run each frame, since we're possibly modifying the captureTimer for the capturePoints by dt
 void CapturePointSystem::UpdateComponent(EntityWrapper& capturePointEntity, ComponentWrapper& cCapturePoint, double dt)
 {
-    if (!IsClient) {
-        return;
-    }
-
+    //if (!IsClient) {
+    //    return;
+    //}
     if (m_WinnerWasFound) {
         return;
     }
     const int capturePointNumber = cCapturePoint["CapturePointNumber"];
     const bool hasTeamComponent = capturePointEntity.HasComponent("Team");
 
+    if (m_NumberOfCapturePoints != 0) {
+        if (!m_CapturePointNumberToEntityMap[0].HasComponent("CapturePoint")) {
+            //if map has changed, the capturepoints has changed, now have to redo them
+            m_NumberOfCapturePoints = 0;
+            m_CapturePointNumberToEntityMap.clear();
+        }
+    }
     //if point doesnt have a teamComponent yet, add one. since:
     //what if capture point has no team -> we cant get/use the team enum from it...
     if (!hasTeamComponent) {
@@ -71,8 +76,7 @@ void CapturePointSystem::UpdateComponent(EntityWrapper& capturePointEntity, Comp
     std::map<std::string, int> nextPossibleCapturePoint;
     nextPossibleCapturePoint["Red"] = -1;
     nextPossibleCapturePoint["Blue"] = -1;
-    for (int i = 0; i < m_NumberOfCapturePoints; i++)
-    {
+    for (int i = 0; i < m_NumberOfCapturePoints; i++) {
         if (!m_CapturePointNumberToEntityMap[i].HasComponent("Team")) {
             continue;
         }
@@ -84,8 +88,7 @@ void CapturePointSystem::UpdateComponent(EntityWrapper& capturePointEntity, Comp
             nextPossibleCapturePoint["Blue"] = i + 1;
         }
     }
-    for (int i = m_NumberOfCapturePoints - 1; i >= 0; i--)
-    {
+    for (int i = m_NumberOfCapturePoints - 1; i >= 0; i--) {
         if (!m_CapturePointNumberToEntityMap[i].HasComponent("Team")) {
             continue;
         }
@@ -100,8 +103,7 @@ void CapturePointSystem::UpdateComponent(EntityWrapper& capturePointEntity, Comp
 
     //reset timers and reset the bool that triggers this
     if (m_ResetTimers) {
-        for (int i = 0; i < m_NumberOfCapturePoints; i++)
-        {
+        for (int i = 0; i < m_NumberOfCapturePoints; i++) {
             ComponentWrapper& capturePoint = m_CapturePointNumberToEntityMap[i]["CapturePoint"];
             if ((int)capturePoint["CapturePointNumber"] != nextPossibleCapturePoint["Red"] &&
                 (int)capturePoint["CapturePointNumber"] != nextPossibleCapturePoint["Blue"]) {
@@ -116,8 +118,7 @@ void CapturePointSystem::UpdateComponent(EntityWrapper& capturePointEntity, Comp
     }
 
     //check how many players are standing inside and are healthy
-    for (size_t i = m_ETriggerTouchVector.size(); i > 0; i--)
-    {
+    for (size_t i = m_ETriggerTouchVector.size(); i > 0; i--) {
         auto triggerTouched = m_ETriggerTouchVector[i - 1];
         if (std::get<1>(triggerTouched) == capturePointEntity) {
             //some player has touched this - lets figure out: what team, health
@@ -176,8 +177,8 @@ void CapturePointSystem::UpdateComponent(EntityWrapper& capturePointEntity, Comp
             cCapturePoint["CaptureTimer"] = (double)cCapturePoint["CaptureTimer"] + timerDeltaChange;
         }
         //if capturePoint is owned by the team, and the other team has been trying to take it, then increase/decrease the timer towards 0.0
-        if ((ownedBy == currentTeam && currentTeam == redTeam && (double)cCapturePoint["CaptureTimer"] < 0.0) ||
-            (ownedBy == currentTeam && currentTeam == blueTeam && (double)cCapturePoint["CaptureTimer"] > 0.0)) {
+        if ((ownedBy == currentTeam && currentTeam == redTeam && (double)cCapturePoint["CaptureTimer"] < captureTimeToTakeOver) ||
+            (ownedBy == currentTeam && currentTeam == blueTeam && (double)cCapturePoint["CaptureTimer"] > -captureTimeToTakeOver)) {
             cCapturePoint["CaptureTimer"] = (double)cCapturePoint["CaptureTimer"] + timerDeltaChange;
         }
         //check if captureTimer > captureTimeToTakeOver and if so change owner and publish the eCaptured event
@@ -195,17 +196,14 @@ void CapturePointSystem::UpdateComponent(EntityWrapper& capturePointEntity, Comp
 
     //check for possible winCondition = check if the homebase is owned by the other team
     bool checkForWinner = false;
-    if (capturePointNumber == m_RedTeamHomeCapturePoint && ownedBy != redTeam)
-    {
+    if (capturePointNumber == m_RedTeamHomeCapturePoint && ownedBy != redTeam) {
         checkForWinner = true;
     }
-    if (capturePointNumber == m_BlueTeamHomeCapturePoint && ownedBy != blueTeam)
-    {
+    if (capturePointNumber == m_BlueTeamHomeCapturePoint && ownedBy != blueTeam) {
         checkForWinner = true;
     }
 
-    if (checkForWinner && !m_WinnerWasFound)
-    {
+    if (checkForWinner && !m_WinnerWasFound) {
         //publish Win event
         Events::Win e;
         e.TeamThatWon = ownedBy;
@@ -224,8 +222,7 @@ bool CapturePointSystem::OnTriggerTouch(const Events::TriggerTouch& e)
 
 bool CapturePointSystem::OnTriggerLeave(const Events::TriggerLeave& e)
 {
-    for (size_t i = 0; i < m_ETriggerTouchVector.size(); i++)
-    {
+    for (size_t i = 0; i < m_ETriggerTouchVector.size(); i++) {
         auto triggerTouched = m_ETriggerTouchVector[i];
         if (std::get<0>(triggerTouched) == e.Entity && std::get<1>(triggerTouched) == e.Trigger) {
             m_ETriggerTouchVector.erase(m_ETriggerTouchVector.begin() + i);

--- a/src/Game/Systems/DamageIndicatorSystem.cpp
+++ b/src/Game/Systems/DamageIndicatorSystem.cpp
@@ -12,51 +12,41 @@ DamageIndicatorSystem::DamageIndicatorSystem(SystemParams params)
     auto entityFile = ResourceManager::Load<EntityFile>("Schema/Entities/DamageIndicator.xml");
 }
 
+void DamageIndicatorSystem::Update(double dt) {
+    if (!IsServer) {
+        for (auto& iter = updateDamageIndicatorVector.begin(); iter != updateDamageIndicatorVector.end(); iter++) {
+            if (!iter->spriteEntity.Valid()) {
+                updateDamageIndicatorVector.erase(iter);
+                break;
+            }
+            auto angleBetweenVectors = CalculateAngle(LocalPlayer, iter->enemyPosition);
+            //simply set the rotation z-wise to the angleBetweenVectors
+            iter->spriteEntity["Transform"]["Orientation"] = glm::vec3(0, 0, angleBetweenVectors);
+        }
+    }
+}
+
 bool DamageIndicatorSystem::OnPlayerDamage(Events::PlayerDamage& e)
 {
     if (m_CurrentCamera == EntityID_Invalid) {
         return false;
     }
 
-    //if (e.Victim != LocalPlayer) {
-    //    return false;
-    //}
     if (e.Victim.Valid() && e.Victim != LocalPlayer && !e.Victim.IsChildOf(LocalPlayer)) {
         return false;
     }
 
     if (!e.Inflictor.Valid() || !e.Victim.Valid()) {
-        return false; 
+        return false;
     }
 
-    //grab players direction
-    auto playerOrientation = glm::quat((glm::vec3)e.Victim["Transform"]["Orientation"]);
-
-    //get the position vectors, but ignore the y-height
-    auto enemyPosition = (glm::vec3)e.Inflictor["Transform"]["Position"];
-    auto playerPosition = (glm::vec3)e.Victim["Transform"]["Position"];
-    enemyPosition.y = 0.0f;
-    playerPosition.y = 0.0f;
-
-    //calculate the enemy to player vector
-    auto enemyPlayerVector = glm::normalize(playerPosition - enemyPosition);
-
-    //get angle from players current rotation, this angle is how much you rotate around the y-axis
-    auto playerAngle = glm::angle(playerOrientation);
-    auto playerRotationVector = glm::normalize(glm::rotateY(glm::vec3(0, 0, 1), playerAngle));
-
-    //dot product of players direction-vector and enemys-to-playervector will give the cos of the angle between the vectors
-    auto playerRotationDot = glm::dot(playerRotationVector, enemyPlayerVector);
-    //to get the angle between the vectors just do cos-inverse
-    auto angleBetweenVectors = glm::acos(playerRotationDot);
-
-    //rotate the direction-vector 90 degrees to get the players side-vector
-    auto playerSideVector = glm::normalize(glm::rotateY(glm::vec3(0, 0, 1), playerAngle + 1.57f));
-    //dot of sidevector positive = enemy is on the right side, dot sidevector negative = left side
-    auto playerSideVectorDot = glm::dot(playerSideVector, enemyPlayerVector);
-    if (playerSideVectorDot < 0) {
-        angleBetweenVectors = -angleBetweenVectors;
+    glm::vec3 inflictorPos = e.Inflictor["Transform"]["Position"];
+    //if testing
+    if (m_Testing) {
+        inflictorPos = DamageIndicatorTest(e.Victim);
     }
+
+    float angleBetweenVectors = CalculateAngle(e.Victim, inflictorPos);
 
     //load & set the "2d" sprite
     auto entityFile = ResourceManager::Load<EntityFile>("Schema/Entities/DamageIndicator.xml");
@@ -67,10 +57,91 @@ bool DamageIndicatorSystem::OnPlayerDamage(Events::PlayerDamage& e)
     //simply set the rotation z-wise to the angleBetweenVectors
     spriteWrapper["Transform"]["Orientation"] = glm::vec3(0, 0, angleBetweenVectors);
 
+    if (!IsServer) {
+        updateDamageIndicatorVector.emplace_back(spriteWrapper, inflictorPos);
+    }
+
     return true;
 }
 
 bool DamageIndicatorSystem::OnSetCamera(const Events::SetCamera& e) {
     m_CurrentCamera = e.CameraEntity.ID;
     return true;
+}
+
+float DamageIndicatorSystem::CalculateAngle(EntityWrapper player, glm::vec3 enemyPos) {
+    //grab players direction
+    auto playerOrientation = glm::quat((glm::vec3)player["Transform"]["Orientation"]);
+
+    //get the position vectors, but ignore the y-height
+    auto enemyPosition = enemyPos;
+    auto playerPosition = (glm::vec3)player["Transform"]["Position"];
+    enemyPosition.y = 0.0f;
+    playerPosition.y = 0.0f;
+
+    //calculate the enemy to player vector
+    auto enemyPlayerVector = glm::normalize(playerPosition - enemyPosition);
+
+    //get the rotationvector relative to the z-axis
+    auto rotationVectorVec3 = glm::vec3(glm::toMat4(Transform::AbsoluteOrientation(player))*glm::vec4(0, 0, 1, 0));
+    //rotate the direction-vector 90 degrees to get the players side-vector
+    auto playerSideVector = glm::vec3(glm::rotateY(rotationVectorVec3, 1.57f));
+
+    //dot product of players direction-vector and enemys-to-playervector will give the cos of the angle between the vectors
+    auto playerRotationDot = glm::dot(rotationVectorVec3, enemyPlayerVector);
+    //to get the angle between the vectors just do cos-inverse
+    auto angleBetweenVectors = glm::acos(playerRotationDot);
+
+    //dot of sidevector positive = enemy is on the right side, dot sidevector negative = left side
+    auto playerSideVectorDot = glm::dot(playerSideVector, enemyPlayerVector);
+    if (playerSideVectorDot < 0) {
+        angleBetweenVectors = -angleBetweenVectors;
+    }
+
+    return angleBetweenVectors;
+}
+glm::vec3 DamageIndicatorSystem::DamageIndicatorTest(EntityWrapper player) {
+    auto currentPos = (glm::vec3)player["Transform"]["Position"];
+
+    auto testVar = 1;
+    auto testVar2 = 1;
+    if (m_TestVar % 4 == 0) {
+        testVar = -1;
+        testVar2 = 1;
+    }
+    if (m_TestVar % 4 == 1) {
+        testVar = 1;
+        testVar2 = 1;
+    }
+    if (m_TestVar % 4 == 2) {
+        testVar *= -1;
+        testVar2 = -1;
+    }
+    if (m_TestVar % 4 == 3) {
+        testVar = 1;
+        testVar2 = -1;
+    }
+    m_TestVar++;
+
+     auto inflictorPos = glm::vec3(currentPos.x + testVar*6.0f, currentPos.y, currentPos.z + testVar2*6.0f);
+
+    //load the explosioneffect XML
+    auto deathEffect = ResourceManager::Load<EntityFile>("Schema/Entities/PlayerDeathExplosionWithCamera.xml");
+    EntityFileParser parser(deathEffect);
+    EntityID deathEffectID = parser.MergeEntities(m_World);
+    EntityWrapper deathEffectEW = EntityWrapper(m_World, deathEffectID);
+
+    //components that we need from player
+    auto playerModel = player.FirstChildByName("PlayerModel");
+    auto playerEntityModel = playerModel["Model"];
+    auto playerEntityAnimation = playerModel["Animation"];
+
+    //copy the data from player to explosioneffectmodel
+    playerEntityModel.Copy(deathEffectEW["Model"]);
+    playerEntityAnimation.Copy(deathEffectEW["Animation"]);
+
+    //copy the models position,orientation
+    deathEffectEW["Transform"]["Position"] = inflictorPos;
+    deathEffectEW["Transform"]["Orientation"] = (glm::vec3)player["Transform"]["Orientation"];
+    return inflictorPos;
 }

--- a/src/Game/Systems/DamageIndicatorSystem.cpp
+++ b/src/Game/Systems/DamageIndicatorSystem.cpp
@@ -42,9 +42,9 @@ bool DamageIndicatorSystem::OnPlayerDamage(Events::PlayerDamage& e)
 
     glm::vec3 inflictorPos = e.Inflictor["Transform"]["Position"];
     //if testing
-    if (m_Testing) {
+#ifdef INDICATOR_TEST
         inflictorPos = DamageIndicatorTest(e.Victim);
-    }
+#endif
 
     float angleBetweenVectors = CalculateAngle(e.Victim, inflictorPos);
 
@@ -100,6 +100,7 @@ float DamageIndicatorSystem::CalculateAngle(EntityWrapper player, glm::vec3 enem
 
     return angleBetweenVectors;
 }
+#ifdef INDICATOR_TEST
 glm::vec3 DamageIndicatorSystem::DamageIndicatorTest(EntityWrapper player) {
     auto currentPos = (glm::vec3)player["Transform"]["Position"];
 
@@ -145,3 +146,4 @@ glm::vec3 DamageIndicatorSystem::DamageIndicatorTest(EntityWrapper player) {
     deathEffectEW["Transform"]["Orientation"] = (glm::vec3)player["Transform"]["Orientation"];
     return inflictorPos;
 }
+#endif

--- a/src/Game/Systems/PlayerDeathSystem.cpp
+++ b/src/Game/Systems/PlayerDeathSystem.cpp
@@ -33,9 +33,8 @@ void PlayerDeathSystem::createDeathEffect(EntityWrapper player)
     EntityWrapper deathEffectEW = EntityWrapper(m_World, deathEffectID);
 
     //components that we need from player
-    auto playerCamera = player.FirstChildByName("Camera");
     auto playerModel = player.FirstChildByName("PlayerModel");
-    if (!playerCamera.Valid() || !playerModel.Valid()) {
+    if (!playerModel.Valid()) {
         return;
     }
     if (!playerModel.HasComponent("Model") || !playerModel.HasComponent("Animation")) {
@@ -44,7 +43,7 @@ void PlayerDeathSystem::createDeathEffect(EntityWrapper player)
     auto playerEntityModel = playerModel["Model"];
     auto playerEntityAnimation = playerModel["Animation"];
 
-    //copy the data from player to explisioneffectmodel
+    //copy the data from player to explosioneffectmodel
     playerEntityModel.Copy(deathEffectEW["Model"]);
     playerEntityAnimation.Copy(deathEffectEW["Animation"]);
     //freeze the animation

--- a/src/Tests/HealthSystemTest.h
+++ b/src/Tests/HealthSystemTest.h
@@ -6,7 +6,6 @@
 #include "Core/EventBroker.h"
 #include "Rendering/Renderer.h"
 #include "Core/InputManager.h"
-#include "GUI/Frame.h"
 #include "Core/World.h"
 #include "Input/InputProxy.h"
 #include "Input/KeyboardInputHandler.h"


### PR DESCRIPTION
CapturePointSystem fix:
- Other team can now "take back" their capturepoint after the "halfway mark"

DamageIndicatorSystem fix&enhancement
- Indicatordirection fixed. Enhanced to update the indicators as you move your player around.
- Added a test for DamageIndicatorSystem 
