### PR TITLE
Teleporting to origin on spawn fixed.

### DIFF
--- a/include/Engine/Collision/CollisionSystem.h
+++ b/include/Engine/Collision/CollisionSystem.h
@@ -24,6 +24,7 @@ public:
 private:
     Octree<EntityAABB>* m_Octree;
     std::vector<EntityAABB> m_OctreeResult;
+    std::unordered_map<EntityWrapper, glm::vec3> m_PrevPositions;
 };
 
 #endif

--- a/resources/Schema/Components/Physics.xml
+++ b/resources/Schema/Components/Physics.xml
@@ -2,7 +2,6 @@
 <Physics xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="Physics.xsd">
 	<Velocity X="0" Y="0" Z="0"/>
 	<Gravity>true</Gravity>
-	<PrevOrigin X="-9876.5" Y="-9876.5" Z="-9876.5"/>
 	<IsOnGround>false</IsOnGround>
 	<VerticalStepHeight>0.33</VerticalStepHeight>
 </Physics>

--- a/resources/Schema/Components/Physics.xsd
+++ b/resources/Schema/Components/Physics.xsd
@@ -13,7 +13,6 @@
 					<xs:annotation><xs:documentation>m/s^2</xs:documentation></xs:annotation>
 				</xs:element>
 				<xs:element name="Gravity" type="t:bool" minOccurs="0"/>
-				<xs:element name="PrevOrigin" type="t:Vector" minOccurs="0"/>
 				<xs:element name="IsOnGround" type="t:bool" minOccurs="0"/>
 				<xs:element name="VerticalStepHeight" type="t:double" minOccurs="0">
 					<xs:annotation><xs:documentation>The largest height of a "stair-step" that can be walked over</xs:documentation></xs:annotation>

--- a/resources/Schema/Entities/Player.xml
+++ b/resources/Schema/Entities/Player.xml
@@ -13,7 +13,6 @@
     <c:DashAbility/>
     <c:Health/>
     <c:Physics>
-      <PrevOrigin X="0" Y="0.772000015" Z="0"/>
       <Velocity X="2.30999646e-23" Y="0" Z="1.05272533e-23"/>
     </c:Physics>
     <c:Player>

--- a/resources/Schema/Entities/PlayerRed.xml
+++ b/resources/Schema/Entities/PlayerRed.xml
@@ -13,7 +13,6 @@
     <c:DashAbility/>
     <c:Health/>
     <c:Physics>
-      <PrevOrigin X="0" Y="0.772000015" Z="0"/>
       <Velocity X="2.30999646e-23" Y="0" Z="1.05272533e-23"/>
     </c:Physics>
     <c:Player>

--- a/src/Engine/Collision/CollisionSystem.cpp
+++ b/src/Engine/Collision/CollisionSystem.cpp
@@ -16,51 +16,51 @@ void CollisionSystem::UpdateComponent(EntityWrapper& entity, ComponentWrapper& c
     EntityAABB& boxA = *boundingBox;
     bool everHitTheGround = false;
 
-    glm::vec3 size = boxA.Size();
-    float diameter = std::min(size.x, size.z);
-    glm::vec3 prevOrigin = (glm::vec3)cPhysics["PrevOrigin"];
-    glm::vec3 toCurrentPos = boxA.Origin() - prevOrigin;
-    float rayLength = glm::length(toCurrentPos) + 0.5f*diameter;
-    //If the entity has moved farther than the size of its box, we need to handle it specially.
-    bool traceCollision = rayLength > diameter;
-    //hack solution: If prevOrigin is less than -9000 in all dimensions, 
-    //then it means it is not set, i.e. this is the first collision check for the entity.
-    if (traceCollision && glm::any(glm::greaterThan((glm::vec3)cPhysics["PrevOrigin"], glm::vec3(-9000.f)))) {
-        Ray ray(prevOrigin, toCurrentPos);
-        m_OctreeResult.clear();
-        m_Octree->ObjectsPossiblyHitByRay(ray, m_OctreeResult);
-        for (auto& boxB : m_OctreeResult) {
-            if (boxA.Entity == boxB.Entity) {
-                continue;
-            }
-            bool hit;
-            float dist;
-            if (boxB.Entity.HasComponent("Model")) {
-                RawModel* model;
-                std::string res = (std::string)boxB.Entity["Model"]["Resource"];
-                try {
-                    model = ResourceManager::Load<RawModel, true>(res);
-                } catch (const std::exception&) {
+    auto prevPosIt = m_PrevPositions.find(entity);
+    if (prevPosIt != m_PrevPositions.end()) {
+        glm::vec3 size = boxA.Size();
+        float diameter = std::min(size.x, size.z);
+        glm::vec3 prevOrigin = prevPosIt->second;
+        glm::vec3 toCurrentPos = boxA.Origin() - prevOrigin;
+        float rayLength = glm::length(toCurrentPos) + 0.5f*diameter;
+        //If the entity has moved farther than the size of its box, we need to handle it specially.
+        if (rayLength > diameter) {
+            Ray ray(prevOrigin, toCurrentPos);
+            m_OctreeResult.clear();
+            m_Octree->ObjectsPossiblyHitByRay(ray, m_OctreeResult);
+            for (auto& boxB : m_OctreeResult) {
+                if (boxA.Entity == boxB.Entity) {
                     continue;
                 }
-                float u, v;
-                hit = Collision::RayVsModel(ray, model->Vertices(), model->m_Indices, Transform::ModelMatrix(boxB.Entity), dist, u, v);
-            } else {
-                hit = Collision::RayVsAABB(ray, boxB, dist);
-            }
-            if (hit && dist < rayLength) {
-                //Set the entity to where it was colliding, minus the maximum box size. 
-                //TODO: Perhaps this should be done slightly more properly.
-                glm::vec3 newOriginPos = ray.Origin() + (dist - 0.707107f*diameter) * ray.Direction();
-                glm::vec3 resolve = newOriginPos - boxA.Origin();
-                (glm::vec3&)cTransform["Position"] += resolve;
-                boxA = *Collision::EntityAbsoluteAABB(entity);
-                if (resolve.y > 0) {
-                    everHitTheGround = true;
-                    (bool)cPhysics["IsOnGround"] = true;
-                    ((glm::vec3&)cPhysics["Velocity"]).y = 0.f;
+                bool hit;
+                float dist;
+                if (boxB.Entity.HasComponent("Model")) {
+                    RawModel* model;
+                    std::string res = (std::string)boxB.Entity["Model"]["Resource"];
+                    try {
+                        model = ResourceManager::Load<RawModel, true>(res);
+                    } catch (const std::exception&) {
+                        continue;
+                    }
+                    float u, v;
+                    hit = Collision::RayVsModel(ray, model->Vertices(), model->m_Indices, Transform::ModelMatrix(boxB.Entity), dist, u, v);
+                } else {
+                    hit = Collision::RayVsAABB(ray, boxB, dist);
                 }
-                break;
+                if (hit && dist < rayLength) {
+                    //Set the entity to where it was colliding, minus the maximum box size. 
+                    //TODO: Perhaps this should be done slightly more properly.
+                    glm::vec3 newOriginPos = ray.Origin() + (dist - 0.707107f*diameter) * ray.Direction();
+                    glm::vec3 resolve = newOriginPos - boxA.Origin();
+                    (glm::vec3&)cTransform["Position"] += resolve;
+                    boxA = *Collision::EntityAbsoluteAABB(entity);
+                    if (resolve.y > 0) {
+                        everHitTheGround = true;
+                        (bool)cPhysics["IsOnGround"] = true;
+                        ((glm::vec3&)cPhysics["Velocity"]).y = 0.f;
+                    }
+                    break;
+                }
             }
         }
     }
@@ -90,6 +90,7 @@ void CollisionSystem::UpdateComponent(EntityWrapper& entity, ComponentWrapper& c
             float verticalStepHeight = (float)(double)cPhysics["VerticalStepHeight"];
             if (Collision::AABBvsTriangles(boxA, model->Vertices(), model->m_Indices, modelMatrix, inOutVelocity, verticalStepHeight, isOnGround, resolutionVector)) {
                 (glm::vec3&)cTransform["Position"] += resolutionVector;
+                boxA = *Collision::EntityAbsoluteAABB(entity);
                 cPhysics["Velocity"] = inOutVelocity;
                 if (isOnGround) {
                     everHitTheGround = true;
@@ -99,6 +100,7 @@ void CollisionSystem::UpdateComponent(EntityWrapper& entity, ComponentWrapper& c
         } else if (Collision::AABBVsAABB(boxA, boxB, resolutionVector)) {
             //Enter here if boxB has no Model.
             (glm::vec3&)cTransform["Position"] += resolutionVector;
+            boxA = *Collision::EntityAbsoluteAABB(entity);
             if (resolutionVector.y > 0) {
                 everHitTheGround = true;
                 (bool)cPhysics["IsOnGround"] = true;
@@ -112,5 +114,5 @@ void CollisionSystem::UpdateComponent(EntityWrapper& entity, ComponentWrapper& c
         (bool)cPhysics["IsOnGround"] = false;
     }
 
-    (glm::vec3&)cPhysics["PrevOrigin"] = boxA.Origin();
+    m_PrevPositions[entity] = boxA.Origin();
 }


### PR DESCRIPTION
There was a problem with the previous position for players being saved in their .xml file, so when they were loaded into the game they were forced back to the position that was saved when the file was edited. 

The previous position for all moving collidables (i.e. Players) is saved in a map in CollisionSystem and not as a field in Physics component so it won't be saved when editing Players.
