### PR TITLE
Death explosion should always get triggered now.

### DIFF
--- a/include/Engine/Network/Client.h
+++ b/include/Engine/Network/Client.h
@@ -19,6 +19,7 @@
 #include "Core/World.h"
 #include "Core/EventBroker.h"
 #include "Core/ConfigFile.h"
+#include "Core/EPlayerDeath.h"
 #include "Input/EInputCommand.h"
 #include "Core/EPlayerDamage.h"
 #include "../Game/Events/EDoubleJump.h"

--- a/src/Engine/Network/Client.cpp
+++ b/src/Engine/Network/Client.cpp
@@ -261,8 +261,14 @@ void Client::parseEntityDeletion(Packet & packet)
     if (m_ServerIDToClientID.find(entityToDelete) != m_ServerIDToClientID.end()) {
         EntityID localEntity = m_ServerIDToClientID.at(entityToDelete);
         if (m_World->ValidEntity(localEntity)) {
-            m_World->DeleteEntity(localEntity);
-            deleteFromServerClientMaps(entityToDelete, localEntity);
+            if (m_World->HasComponent(localEntity,"Player")) {
+                Events::PlayerDeath e;
+                e.Player = EntityWrapper(m_World, localEntity);
+                m_EventBroker->Publish(e);
+            } else {
+                m_World->DeleteEntity(localEntity);
+                deleteFromServerClientMaps(entityToDelete, localEntity);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixed explosion effect by publishing a death event instead of deleting the entity if it is a player. This is done in Client.cpp
