### PR TITLE
Added CapturePointGameMode component with RespawnTime

### DIFF
--- a/include/Game/Systems/PlayerSpawnSystem.h
+++ b/include/Game/Systems/PlayerSpawnSystem.h
@@ -13,8 +13,6 @@ public:
     PlayerSpawnSystem(SystemParams params);
 
     virtual void Update(double dt) override;
-    
-    static void SetRespawnTime(float respawnTime) { m_RespawnTime = respawnTime; };
 
 private:
     struct SpawnRequest
@@ -31,8 +29,8 @@ private:
     //EntityWrapper ID -> Player ID.
     std::map<EntityID, int> m_PlayerIDs;
 
-    static float m_RespawnTime;
-    float m_Timer;
+    float m_ForcedRespawnTime;
+    bool m_DbgConfigForceRespawn;
 
     EventRelay<PlayerSpawnSystem, Events::InputCommand> m_OnInputCommand;
     bool OnInputCommand(Events::InputCommand& e);

--- a/resources/Schema/Components.xsd
+++ b/resources/Schema/Components.xsd
@@ -48,4 +48,5 @@
 	<xs:include schemaLocation="Components/Button.xsd"/>
 	<xs:include schemaLocation="Components/WeaponAttachment.xsd"/>
 	<xs:include schemaLocation="Components/DefenderWeapon.xsd"/>
+	<xs:include schemaLocation="Components/CapturePointGameMode.xsd"/>
 </xs:schema>

--- a/resources/Schema/Components/CapturePointGameMode.xml
+++ b/resources/Schema/Components/CapturePointGameMode.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CapturePointGameMode xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CapturePointGameMode.xsd">
+	<RespawnTime>0.0</RespawnTime>
+	<MaxRespawnTime>8.0</MaxRespawnTime>
+</CapturePointGameMode>

--- a/resources/Schema/Components/CapturePointGameMode.xsd
+++ b/resources/Schema/Components/CapturePointGameMode.xsd
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:t="types">
+	<xs:import schemaLocation="../Types.xsd" namespace="types"/>
+
+	<xs:element name="CapturePointGameMode">
+		<xs:complexType>
+			<xs:all>
+				<xs:element name="RespawnTime" type="t:double" minOccurs="0">
+					<xs:annotation><xs:documentation>The time since the last respawn wave. Players will be spawned when this reaches MaxRespawnTime.</xs:documentation></xs:annotation>
+				</xs:element>
+				<xs:element name="MaxRespawnTime" type="t:double" minOccurs="0">
+					<xs:annotation><xs:documentation>Players will be spawned when RespawnTime reaches this.</xs:documentation></xs:annotation>
+				</xs:element>
+			</xs:all>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -48,7 +48,6 @@ Game::Game(int argc, char* argv[])
     ResourceManager::UseThreading = m_Config->Get<bool>("Multithreading.ResourceLoading", true);
     DisableMemoryPool::Value = m_Config->Get<bool>("Debug.DisableMemoryPool", false);
     LOG_LEVEL = static_cast<_LOG_LEVEL>(m_Config->Get<int>("Debug.LogLevel", 1));
-    PlayerSpawnSystem::SetRespawnTime(m_Config->Get<float>("Debug.RespawnTime", 15.0f));
 
     // Create the core event broker
     m_EventBroker = new EventBroker();

--- a/src/Game/Systems/PlayerSpawnSystem.cpp
+++ b/src/Game/Systems/PlayerSpawnSystem.cpp
@@ -1,29 +1,40 @@
 #include "Systems/PlayerSpawnSystem.h"
 
-//This should be set by the config anyway.
-float PlayerSpawnSystem::m_RespawnTime = 15.0f;
-
 PlayerSpawnSystem::PlayerSpawnSystem(SystemParams params)
     : System(params)
-    , m_Timer(0.f)
+    , m_DbgConfigForceRespawn(false)
 {
     EVENT_SUBSCRIBE_MEMBER(m_OnInputCommand, &PlayerSpawnSystem::OnInputCommand);
     EVENT_SUBSCRIBE_MEMBER(m_OnPlayerSpawnerd, &PlayerSpawnSystem::OnPlayerSpawned);
     EVENT_SUBSCRIBE_MEMBER(m_OnPlayerDeath, &PlayerSpawnSystem::OnPlayerDeath);
-    m_NetworkEnabled = ResourceManager::Load<ConfigFile>("Config.ini")->Get("Networking.StartNetwork", false);
+    ConfigFile* config = ResourceManager::Load<ConfigFile>("Config.ini");
+    m_NetworkEnabled = config->Get("Networking.StartNetwork", false);
+    m_ForcedRespawnTime = config->Get("Debug.RespawnTime", -1.0f);
+    m_DbgConfigForceRespawn = m_ForcedRespawnTime > 0;
 }
 
 void PlayerSpawnSystem::Update(double dt)
 {
-    //Increase timer.
-    m_Timer += dt;
-    if (m_Timer < m_RespawnTime) {
-        return;
+    // If there are no CapturePointGameMode components we will just spawn immediately.
+    // Should be able to support older maps with this.
+    // TODO: In the future we might want to return instead, to avoid spawning in the menu for instance.
+    auto pool = m_World->GetComponents("CapturePointGameMode");
+    if (pool != nullptr)
+    {
+        // Take the first CapturePointGameMode component found.
+        ComponentWrapper& modeComponent = *pool->begin();
+        // Increase timer.
+        double& timer = (double&)modeComponent["RespawnTime"];
+        timer += dt;
+        double maxRespawnTime = m_DbgConfigForceRespawn ? m_ForcedRespawnTime : (double)modeComponent["MaxRespawnTime"];
+        if (timer < maxRespawnTime) {
+            return;
+        }
+        // If respawn time has passed, we spawn all players that have requested to be spawned.
+        timer = 0;
     }
-    //If respawn time has passed, we spawn all players that have requested to be spawned.
-    m_Timer = 0.f;
 
-    //If there are no spawn requests, return immediately, if we are client the SpawnRequests should always be empty.
+    // If there are no spawn requests, return immediately, if we are client the SpawnRequests should always be empty.
     if (m_SpawnRequests.size() == 0) {
         return;
     }

--- a/src/Game/Systems/PlayerSpawnSystem.cpp
+++ b/src/Game/Systems/PlayerSpawnSystem.cpp
@@ -19,7 +19,7 @@ void PlayerSpawnSystem::Update(double dt)
     // Should be able to support older maps with this.
     // TODO: In the future we might want to return instead, to avoid spawning in the menu for instance.
     auto pool = m_World->GetComponents("CapturePointGameMode");
-    if (pool != nullptr)
+    if (pool != nullptr && pool->size() > 0)
     {
         // Take the first CapturePointGameMode component found.
         ComponentWrapper& modeComponent = *pool->begin();


### PR DESCRIPTION
New component CapturePointGameMode that can be attached to the level entity (or anywhere in the level, but there should only be one per level). It contains a field RespawnTime that will increase as time passes, and when it reaches MaxRespawnTime (another component field) it will reset to zero and spawn any players.

If a the level doesn't have a CapturePointGameMode component, then players will be spawned immediately (as if the time to spawn is 0), so we can still spawn on the older maps that lacks the component.

In the config file, if you set the RespawnTime under [debug] to any positive value, the waiting time will be forced to that value. I maintained this behavior for debug purposes. E.g you can set it to zero to spawn immediately regardless of what MaxRespawnTime is in the component. Note: the RespawnTime in config has no effect whatsoever if there is no CapturePointGameMode in the map, if that is the case, the above paragraph applies (i.e. respawn time is zero).
