### PR TITLE
Transparency fix

### DIFF
--- a/resources/Shaders/ForwardPlus.frag.glsl
+++ b/resources/Shaders/ForwardPlus.frag.glsl
@@ -169,8 +169,9 @@ void main()
 
 	vec4 color_result = mix((Color * diffuseTexel * DiffuseColor), Input.ExplosionColor, Input.ExplosionPercentageElapsed);
 	color_result = color_result * (totalLighting.Diffuse + (totalLighting.Specular * specularTexel));
-	//float specularResult = (specularTexel.r + specularTexel.g + specularTexel.b)/3.0;
-	//color_result = color_result * clamp(1/specularTexel, 0, 1)*2 + reflectionColor * clamp(specularTexel, 0, 1)/2;
+	float specularResult = (specularTexel.r + specularTexel.g + specularTexel.b)/3.0;
+	vec4 reflectionTotal = reflectionColor * (1-specularTexel.a) * color_result.a;
+	color_result = color_result * clamp(1/specularTexel.a, 0, 1) + reflectionTotal;
 	//vec4 color_result = (DiffuseColor + Input.ExplosionColor) * (totalLighting.Diffuse + (totalLighting.Specular * specularTexel)) * diffuseTexel * Color;
 	
 

--- a/resources/Shaders/ForwardPlus.frag.glsl
+++ b/resources/Shaders/ForwardPlus.frag.glsl
@@ -169,8 +169,8 @@ void main()
 
 	vec4 color_result = mix((Color * diffuseTexel * DiffuseColor), Input.ExplosionColor, Input.ExplosionPercentageElapsed);
 	color_result = color_result * (totalLighting.Diffuse + (totalLighting.Specular * specularTexel));
-	float specularResult = (specularTexel.r + specularTexel.g + specularTexel.b)/3.0;
-	color_result = color_result * clamp(1/specularTexel, 0, 1)*2 + reflectionColor * clamp(specularTexel, 0, 1)/2;
+	//float specularResult = (specularTexel.r + specularTexel.g + specularTexel.b)/3.0;
+	//color_result = color_result * clamp(1/specularTexel, 0, 1)*2 + reflectionColor * clamp(specularTexel, 0, 1)/2;
 	//vec4 color_result = (DiffuseColor + Input.ExplosionColor) * (totalLighting.Diffuse + (totalLighting.Specular * specularTexel)) * diffuseTexel * Color;
 	
 
@@ -181,9 +181,9 @@ void main()
 	}
 	sceneColor = vec4(color_result.xyz, clamp(color_result.a, 0, 1));
 	//sceneColor = vec4(reflectionColor.xyz, 1);
-	color_result += glowTexel*GlowIntensity;
+	color_result.xyz += glowTexel.xyz*GlowIntensity;
 
-	bloomColor = vec4(clamp(color_result.xyz - 1.0, 0, 100), clamp(color_result.a, 0, 1));
+	bloomColor = vec4(max(color_result.xyz - 1.0, 0.0), clamp(color_result.a, 0, 1));
 
 	//Tiled Debug Code
 	/*

--- a/src/Engine/Rendering/DrawFinalPass.cpp
+++ b/src/Engine/Rendering/DrawFinalPass.cpp
@@ -193,10 +193,12 @@ void DrawFinalPass::Draw(RenderScene& scene, GLuint SSAOTexture)
     state->StencilMask(0x00);
     DrawModelRenderQueues(scene.Jobs.OpaqueObjects, scene, SSAOTexture);
     GLERROR("OpaqueObjects");
-    state->BlendFunc(GL_ONE, GL_ONE);
+    //state->BlendFunc(GL_ONE, GL_ONE);
+    state->BlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
     DrawModelRenderQueues(scene.Jobs.TransparentObjects, scene, SSAOTexture);
     GLERROR("TransparentObjects");
-    state->BlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    //state->BlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     DrawSprites(scene.Jobs.SpriteJob, scene);
     GLERROR("SpriteJobs");
 


### PR DESCRIPTION
## Added

**Transparency fix**, **bloom** should now show behind transparent objects without conflicting with the transparent object rendering.
**Reflections** are now based on the specular maps inverse alpha value. 
