### PR TITLE
ECaptured: added NextCapturePoint entitywrapper. Changed CapturePoint…

### DIFF
--- a/include/Engine/Core/ECaptured.h
+++ b/include/Engine/Core/ECaptured.h
@@ -12,7 +12,8 @@ namespace Events
 struct Captured : Event
 {
     int TeamNumberThatCapturedCapturePoint;
-    EntityID CapturePointID;
+    EntityID CapturePointTakenID;
+    EntityWrapper NextCapturePoint;
 };
 
 }

--- a/include/Game/Systems/CapturePointSystem.h
+++ b/include/Game/Systems/CapturePointSystem.h
@@ -42,9 +42,9 @@ private:
     int m_NumberOfCapturePoints = 0;
     std::map<int, EntityWrapper> m_CapturePointNumberToEntityMap;
 
-    //std::vector<ComponentWrapper>
-
     bool m_ResetTimers = false;
+    bool m_RecentlyCapturedNeedNextCapturePointNow = false;
+    Events::Captured m_CapturedEvent;
 
     //vectors which will keep track of enter/leave changes
     std::vector<std::tuple<EntityWrapper, EntityWrapper>> m_ETriggerTouchVector;

--- a/src/Game/Systems/CapturePointSystem.cpp
+++ b/src/Game/Systems/CapturePointSystem.cpp
@@ -6,7 +6,7 @@ CapturePointSystem::CapturePointSystem(SystemParams params)
     , PureSystem("CapturePoint")
 {
     //subscribe/listenTo playerdamage,healthpickup events (using the eventBroker)
-    if (!IsClient) {
+    if (IsServer) {
         EVENT_SUBSCRIBE_MEMBER(m_ETriggerTouch, &CapturePointSystem::OnTriggerTouch);
         EVENT_SUBSCRIBE_MEMBER(m_ETriggerLeave, &CapturePointSystem::OnTriggerLeave);
         EVENT_SUBSCRIBE_MEMBER(m_ECaptured, &CapturePointSystem::OnCaptured);
@@ -18,7 +18,7 @@ CapturePointSystem::CapturePointSystem(SystemParams params)
 //NOTE: needs to run each frame, since we're possibly modifying the captureTimer for the capturePoints by dt
 void CapturePointSystem::UpdateComponent(EntityWrapper& capturePointEntity, ComponentWrapper& cCapturePoint, double dt)
 {
-    if (IsClient) {
+    if (!IsServer) {
         return;
     }
     if (m_WinnerWasFound) {
@@ -78,6 +78,9 @@ void CapturePointSystem::UpdateComponent(EntityWrapper& capturePointEntity, Comp
     std::map<std::string, int> nextPossibleCapturePoint;
     nextPossibleCapturePoint["Red"] = -1;
     nextPossibleCapturePoint["Blue"] = -1;
+    if (m_RecentlyCapturedNeedNextCapturePointNow) {
+        nextPossibleCapturePoint["Blue"] = -2;
+    }
     for (int i = 0; i < m_NumberOfCapturePoints; i++) {
         if (!m_CapturePointNumberToEntityMap[i].HasComponent("Team")) {
             continue;
@@ -101,6 +104,13 @@ void CapturePointSystem::UpdateComponent(EntityWrapper& capturePointEntity, Comp
         if ((int)capturePointOwnedBy["Team"] == blueTeam && m_BlueTeamHomeCapturePoint != 0) {
             nextPossibleCapturePoint["Blue"] = i - 1;
         }
+    }
+    if (m_RecentlyCapturedNeedNextCapturePointNow) {
+        m_CapturedEvent.NextCapturePoint = m_CapturedEvent.TeamNumberThatCapturedCapturePoint == blueTeam ?
+            m_CapturePointNumberToEntityMap[nextPossibleCapturePoint["Blue"]] :
+            m_CapturePointNumberToEntityMap[nextPossibleCapturePoint["Red"]];
+        m_EventBroker->Publish(m_CapturedEvent);
+        m_RecentlyCapturedNeedNextCapturePointNow = false;
     }
 
     //reset timers and reset the bool that triggers this
@@ -188,10 +198,9 @@ void CapturePointSystem::UpdateComponent(EntityWrapper& capturePointEntity, Comp
             teamComponent["Team"] = currentTeam;
             cCapturePoint["CaptureTimer"] = glm::sign((double)cCapturePoint["CaptureTimer"])*captureTimeToTakeOver;
             //publish Captured event
-            Events::Captured e;
-            e.CapturePointID = cCapturePoint.EntityID;
-            e.TeamNumberThatCapturedCapturePoint = currentTeam;
-            m_EventBroker->Publish(e);
+            m_RecentlyCapturedNeedNextCapturePointNow = true;
+            m_CapturedEvent.CapturePointTakenID = cCapturePoint.EntityID;
+            m_CapturedEvent.TeamNumberThatCapturedCapturePoint = currentTeam;
             //NextPossibleCapturePoint will be calculated in the next update...
         }
     }

--- a/src/Game/Systems/CapturePointSystem.cpp
+++ b/src/Game/Systems/CapturePointSystem.cpp
@@ -78,9 +78,6 @@ void CapturePointSystem::UpdateComponent(EntityWrapper& capturePointEntity, Comp
     std::map<std::string, int> nextPossibleCapturePoint;
     nextPossibleCapturePoint["Red"] = -1;
     nextPossibleCapturePoint["Blue"] = -1;
-    if (m_RecentlyCapturedNeedNextCapturePointNow) {
-        nextPossibleCapturePoint["Blue"] = -2;
-    }
     for (int i = 0; i < m_NumberOfCapturePoints; i++) {
         if (!m_CapturePointNumberToEntityMap[i].HasComponent("Team")) {
             continue;

--- a/src/Game/Systems/SoundSystem.cpp
+++ b/src/Game/Systems/SoundSystem.cpp
@@ -94,7 +94,7 @@ bool SoundSystem::OnCaptured(const Events::Captured & e)
     if (!LocalPlayer.Valid()) {
         return false;
     }
-    int homeTeam = (int)m_World->GetComponent(e.CapturePointID, "Team")["Team"];
+    int homeTeam = (int)m_World->GetComponent(e.CapturePointTakenID, "Team")["Team"];
     int team = (int)m_World->GetComponent(LocalPlayer.ID, "Team")["Team"];
     Events::PlaySoundOnEntity ev;
     if (team == homeTeam) {


### PR DESCRIPTION
- ECaptured: added NextCapturePoint entitywrapper. 
  Changed CapturePointID to CapturePointTakenID. 
- Fixed so CapturePoints works in singleplayer again. 
- Captured event is now sent in the next Update, 
  since the information for NextCapturePoint is needed
