### PR TITLE
Properly unlocked mouse

### DIFF
--- a/include/Game/Systems/SpectatorCameraSystem.h
+++ b/include/Game/Systems/SpectatorCameraSystem.h
@@ -3,6 +3,7 @@
 
 #include "Core/System.h"
 #include "Input/EInputCommand.h"
+#include "Network/EPlayerDisconnected.h"
 
 class SpectatorCameraSystem : public ImpureSystem
 {
@@ -17,6 +18,8 @@ private:
 
     EventRelay<SpectatorCameraSystem, Events::InputCommand> m_EInputCommand;
     bool OnInputCommand(const Events::InputCommand& e);
+    EventRelay<SpectatorCameraSystem, Events::PlayerDisconnected> m_EDisconnect;
+    bool OnDisconnect(const Events::PlayerDisconnected& e);
 };
 
 #endif

--- a/resources/DefaultInput.ini
+++ b/resources/DefaultInput.ini
@@ -30,3 +30,5 @@ F2=PerformanceTimingResetAllTimers
 F3=PerformanceTimingCreateExcelData
 Comma=SwapToClassPick
 Period=SwapToTeamPick
+Enter=PickClass,1
+F5=DisconnectFromServer

--- a/src/Engine/Editor/EditorSystem.cpp
+++ b/src/Engine/Editor/EditorSystem.cpp
@@ -47,6 +47,7 @@ EditorSystem::EditorSystem(SystemParams params, IRenderer* renderer, RenderFrame
         Enable();
     } else {
         Disable();
+        m_EventBroker->Publish(Events::UnlockMouse());
     }
 }
 

--- a/src/Engine/Network/Client.cpp
+++ b/src/Engine/Network/Client.cpp
@@ -1,4 +1,5 @@
 #include "Network/Client.h"
+#include "Network/EPlayerDisconnected.h"
 using namespace boost::asio::ip;
 
 Client::Client(World* world, EventBroker* eventBroker)
@@ -224,7 +225,7 @@ void Client::parseServerlist(Packet& packet)
 void Client::parseKick()
 {
     LOG_WARNING("You have been kicked from the server.");
-    m_IsConnected = false;
+    disconnect();
 }
 
 void Client::parseSpawnEvents()
@@ -464,6 +465,10 @@ void Client::disconnect()
     Packet packet(MessageType::Disconnect, m_SendPacketID);
     m_Reliable.Send(packet);
     m_Reliable.Disconnect();
+    Events::PlayerDisconnected e;
+    e.Entity = m_LocalPlayer.ID;
+    e.PlayerID = -1;
+    m_EventBroker->Publish(e);
     createMainMenu();
 }
 

--- a/src/Game/Systems/SpectatorCameraSystem.cpp
+++ b/src/Game/Systems/SpectatorCameraSystem.cpp
@@ -8,6 +8,7 @@ SpectatorCameraSystem::SpectatorCameraSystem(SystemParams params)
     , m_PickedTeam(-1)
 {
     EVENT_SUBSCRIBE_MEMBER(m_EInputCommand, &SpectatorCameraSystem::OnInputCommand);
+    EVENT_SUBSCRIBE_MEMBER(m_EDisconnect, &SpectatorCameraSystem::OnDisconnect);
 }
 
 void SpectatorCameraSystem::Update(double dt)
@@ -86,5 +87,18 @@ bool SpectatorCameraSystem::OnInputCommand(const Events::InputCommand& e)
         m_EventBroker->Publish(unlock);
     }
 
+    return true;
+}
+
+bool SpectatorCameraSystem::OnDisconnect(const Events::PlayerDisconnected& e)
+{
+    // If local player gets disconnected, they should be set to 
+    // the spectator camera next time a map loads that has one.
+    if (e.Entity == LocalPlayer.ID) {
+        m_CamSetToTeamPick = false;
+        // They will also be set to menu, so unlock mouse just in case they were in game with locked mouse.
+        Events::UnlockMouse unlock;
+        m_EventBroker->Publish(unlock);
+    }
     return true;
 }


### PR DESCRIPTION
Mouse is always unlocked when the game starts, regardless of EditorEnabled or not. Also unlocked when player disconnects and returns to menu.
