### PR TITLE
Menu

### DIFF
--- a/include/Engine/Rendering/DrawBloomPass.h
+++ b/include/Engine/Rendering/DrawBloomPass.h
@@ -33,13 +33,14 @@ public:
 		if (m_Quality == 0) { 
 			return m_BlackTexture->m_Texture;
 		} else { 
-			return m_GaussianTexture_vert;
+			return m_FinalGaussianTexture;
 		} 
 	}
 
 
 private:
     void GaussianLodPass(GLuint mipMap, GLuint texture);
+    void CombineGaussianBlur();
     Texture* m_BlackTexture;
     Model* m_ScreenQuad;
 
@@ -52,12 +53,15 @@ private:
 
     GLuint m_GaussianTexture_horiz = 0;
     GLuint m_GaussianTexture_vert = 0;
+    GLuint m_FinalGaussianTexture = 0;
 
     FrameBuffer* m_GaussianFrameBuffer_horiz = nullptr;
     FrameBuffer* m_GaussianFrameBuffer_vert = nullptr;
+    FrameBuffer m_GaussianCombineBuffer;
 
     ShaderProgram* m_GaussianProgram_horiz;
     ShaderProgram* m_GaussianProgram_vert;
+    ShaderProgram* m_GaussianCombineProgram;
 
 };
 

--- a/include/Engine/Rendering/DrawBloomPass.h
+++ b/include/Engine/Rendering/DrawBloomPass.h
@@ -49,7 +49,7 @@ private:
     //const LightCullingPass* m_LightCullingPass 
     int m_Iterations;
 	int m_Quality = 0;
-    int m_BloomLod = 4;
+    int m_BloomLod = 5;
 
     GLuint m_GaussianTexture_horiz = 0;
     GLuint m_GaussianTexture_vert = 0;

--- a/include/Engine/Rendering/DrawBloomPass.h
+++ b/include/Engine/Rendering/DrawBloomPass.h
@@ -39,6 +39,7 @@ public:
 
 
 private:
+    void GaussianLodPass(GLuint mipMap, GLuint texture);
     Texture* m_BlackTexture;
     Model* m_ScreenQuad;
 
@@ -47,12 +48,13 @@ private:
     //const LightCullingPass* m_LightCullingPass 
     int m_Iterations;
 	int m_Quality = 0;
+    int m_BloomLod = 4;
 
     GLuint m_GaussianTexture_horiz = 0;
     GLuint m_GaussianTexture_vert = 0;
 
-    FrameBuffer m_GaussianFrameBuffer_horiz;
-    FrameBuffer m_GaussianFrameBuffer_vert;
+    FrameBuffer* m_GaussianFrameBuffer_horiz = nullptr;
+    FrameBuffer* m_GaussianFrameBuffer_vert = nullptr;
 
     ShaderProgram* m_GaussianProgram_horiz;
     ShaderProgram* m_GaussianProgram_vert;

--- a/include/Engine/Rendering/FrameBuffer.h
+++ b/include/Engine/Rendering/FrameBuffer.h
@@ -7,11 +7,12 @@
 class BufferResource
 {
 public:
-    BufferResource(GLuint* resourceHandle, GLenum resourceType, GLenum attachment);
+    BufferResource(GLuint* resourceHandle, GLenum resourceType, GLenum attachment, GLuint mipMapLod);
     
     GLuint* m_ResourceHandle;
     GLenum m_ResourceType;
     GLenum m_Attachment;
+    GLuint m_MipMapLod = 0;
 private:
     
 };
@@ -20,15 +21,15 @@ template <GLenum RESOURCETYPE>
 class ResourceType : public BufferResource
 {
 public:
-    ResourceType(GLuint* resourceHandle, GLenum attachment)
-        : BufferResource(resourceHandle, RESOURCETYPE, attachment) { }
+    ResourceType(GLuint* resourceHandle, GLenum attachment, GLuint mipMapLod)
+        : BufferResource(resourceHandle, RESOURCETYPE, attachment, mipMapLod) { }
 };
 
 class Texture2D : public ResourceType<GL_TEXTURE_2D>
 {
 public:
-    Texture2D(GLuint* resourceHandle, GLenum attachment)
-        : ResourceType(resourceHandle, attachment) { };
+    Texture2D(GLuint* resourceHandle, GLenum attachment, GLuint mipMapLod = 0)
+        : ResourceType(resourceHandle, attachment, mipMapLod) { };
 
     ~Texture2D();
 };
@@ -37,7 +38,7 @@ class RenderBuffer : public ResourceType<GL_RENDERBUFFER>
 {
 public:
     RenderBuffer(GLuint* resourceHandle, GLenum attachment)
-        : ResourceType(resourceHandle, attachment)
+        : ResourceType(resourceHandle, attachment, 0)
     { };
 
     ~RenderBuffer();
@@ -47,7 +48,7 @@ class Texture2DArray : public ResourceType<GL_TEXTURE_2D_ARRAY>
 {
 public:
 	Texture2DArray(GLuint* resourceHandle, GLenum attachment)
-		: ResourceType(resourceHandle, attachment)
+		: ResourceType(resourceHandle, attachment, 0)
 	{ };
 
 	~Texture2DArray();

--- a/include/Engine/Rendering/SpriteJob.h
+++ b/include/Engine/Rendering/SpriteJob.h
@@ -48,6 +48,13 @@ struct SpriteJob : RenderJob
 
         FillColor = fillColor;
         FillPercentage = fillPercentage;
+
+        if((bool)cSprite["KeepRatioX"] == true) {
+            ScaleX = Transform::AbsoluteScale(world, cSprite.EntityID).x;
+        }
+        if ((bool)cSprite["KeepRatioZ"] == true) {
+            ScaleY = Transform::AbsoluteScale(world, cSprite.EntityID).y;
+        }
     };
 
     unsigned int TextureID;
@@ -69,6 +76,8 @@ struct SpriteJob : RenderJob
     bool Pickable;
 	bool IsIndicator = false;
     bool BlurBackground = false;
+    float ScaleX = 1;
+    float ScaleY = 1;
 
     glm::vec4 FillColor = glm::vec4(0);
     float FillPercentage = 0.0;

--- a/include/Engine/Rendering/SpriteJob.h
+++ b/include/Engine/Rendering/SpriteJob.h
@@ -49,11 +49,22 @@ struct SpriteJob : RenderJob
         FillColor = fillColor;
         FillPercentage = fillPercentage;
 
+        glm::vec3 scale = Transform::AbsoluteScale(world, cSprite.EntityID);
+
         if((bool)cSprite["KeepRatioX"] == true) {
-            ScaleX = Transform::AbsoluteScale(world, cSprite.EntityID).x;
+            ScaleX = scale.x;
         }
-        if ((bool)cSprite["KeepRatioZ"] == true) {
-            ScaleY = Transform::AbsoluteScale(world, cSprite.EntityID).y;
+        if ((bool)cSprite["KeepRatioY"] == true) {
+            ScaleY = scale.y;
+        }
+        if((bool)cSprite["KeepRatio"] == true) {
+            if(scale.y >= scale.x) {
+                ScaleY = (scale.x)/(scale.y);
+                ScaleX = 1;
+            } else {
+                ScaleY = 1;
+                ScaleX = (scale.x)/(scale.y);
+            }
         }
     };
 

--- a/include/Engine/Rendering/SpriteJob.h
+++ b/include/Engine/Rendering/SpriteJob.h
@@ -21,13 +21,22 @@ struct SpriteJob : RenderJob
     SpriteJob(ComponentWrapper cSprite, Camera* camera, glm::mat4 matrix, World* world, glm::vec4 fillColor, float fillPercentage, bool depthSorted, bool isIndicator)
         : RenderJob()
     {
-        Model = ResourceManager::Load<::Model>("Models/Core/UnitQuad.mesh");
+        Model = ResourceManager::Load<::Model>((std::string)cSprite["Model"]);
         ::RawModel::MaterialProperties matProp = Model->MaterialGroups().front();
         TextureID = 0;
 
         DiffuseTexture = CommonFunctions::TryLoadResource<TextureSprite, true>(cSprite["DiffuseTexture"]);
-
         IncandescenceTexture = CommonFunctions::TryLoadResource<TextureSprite, true>(cSprite["GlowMap"]);
+
+        if ((bool)cSprite["Linear"]) {
+            glBindTexture(GL_TEXTURE_2D, DiffuseTexture->m_Texture);
+            glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+            glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        } else {
+            glBindTexture(GL_TEXTURE_2D, DiffuseTexture->m_Texture);
+            glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST_MIPMAP_NEAREST);
+            glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        }
 
         StartIndex = matProp.material->StartIndex;
         EndIndex = matProp.material->EndIndex;
@@ -89,6 +98,7 @@ struct SpriteJob : RenderJob
     bool BlurBackground = false;
     float ScaleX = 1;
     float ScaleY = 1;
+    bool Linear = false;
 
     glm::vec4 FillColor = glm::vec4(0);
     float FillPercentage = 0.0;

--- a/include/Engine/Rendering/SpriteJob.h
+++ b/include/Engine/Rendering/SpriteJob.h
@@ -28,15 +28,7 @@ struct SpriteJob : RenderJob
         DiffuseTexture = CommonFunctions::TryLoadResource<TextureSprite, true>(cSprite["DiffuseTexture"]);
         IncandescenceTexture = CommonFunctions::TryLoadResource<TextureSprite, true>(cSprite["GlowMap"]);
 
-        if ((bool)cSprite["Linear"]) {
-            glBindTexture(GL_TEXTURE_2D, DiffuseTexture->m_Texture);
-            glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-            glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-        } else {
-            glBindTexture(GL_TEXTURE_2D, DiffuseTexture->m_Texture);
-            glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST_MIPMAP_NEAREST);
-            glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-        }
+        Linear = (bool)cSprite["Linear"];
 
         StartIndex = matProp.material->StartIndex;
         EndIndex = matProp.material->EndIndex;
@@ -60,21 +52,23 @@ struct SpriteJob : RenderJob
 
         glm::vec3 scale = Transform::AbsoluteScale(world, cSprite.EntityID);
 
-        if((bool)cSprite["KeepRatioX"] == true) {
-            ScaleX = scale.x;
-        }
-        if ((bool)cSprite["KeepRatioY"] == true) {
-            ScaleY = scale.y;
-        }
         if((bool)cSprite["KeepRatio"] == true) {
             if(scale.y >= scale.x) {
                 ScaleY = (scale.x)/(scale.y);
-                ScaleX = 1;
+                ScaleX = 1.f;
             } else {
-                ScaleY = 1;
+                ScaleY = 1.f;
                 ScaleX = (scale.x)/(scale.y);
             }
+        } else {
+            if ((bool)cSprite["KeepRatioX"] == true) {
+                ScaleX = scale.x;
+            }
+            if ((bool)cSprite["KeepRatioY"] == true) {
+                ScaleY = scale.y;
+            }
         }
+
     };
 
     unsigned int TextureID;

--- a/resources/Schema/Components/Model.xml
+++ b/resources/Schema/Components/Model.xml
@@ -9,5 +9,5 @@
 	<SpecularMap>true</SpecularMap>
 	<GlowMap>true</GlowMap>
 	<Shadow>true</Shadow>
-	<GlowIntensity>3.0</GlowIntensity>
+	<GlowIntensity>1.0</GlowIntensity>
 </Model>

--- a/resources/Schema/Components/Sprite.xml
+++ b/resources/Schema/Components/Sprite.xml
@@ -7,5 +7,6 @@
 	<DepthSort>true</DepthSort>
 	<KeepRatioX>false</KeepRatioX>
 	<KeepRatioY>false</KeepRatioY>
+	<KeepRatio>false</KeepRatio>
 	<BlurBackground>false</BlurBackground>
 </Sprite>

--- a/resources/Schema/Components/Sprite.xml
+++ b/resources/Schema/Components/Sprite.xml
@@ -5,5 +5,7 @@
 	<Color R="1" G="1" B="1" A="1"/>
 	<Visible>true</Visible>
 	<DepthSort>true</DepthSort>
+	<KeepRatioX>false</KeepRatioX>
+	<KeepRatioY>false</KeepRatioY>
 	<BlurBackground>false</BlurBackground>
 </Sprite>

--- a/resources/Schema/Components/Sprite.xml
+++ b/resources/Schema/Components/Sprite.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <Sprite xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="Sprite.xsd">
+	<Model>Models/Core/UnitQuad.mesh</Model>
 	<DiffuseTexture></DiffuseTexture>
 	<GlowMap></GlowMap>
 	<Color R="1" G="1" B="1" A="1"/>
@@ -8,5 +9,6 @@
 	<KeepRatioX>false</KeepRatioX>
 	<KeepRatioY>false</KeepRatioY>
 	<KeepRatio>false</KeepRatio>
+	<Linear>false</Linear>
 	<BlurBackground>false</BlurBackground>
 </Sprite>

--- a/resources/Schema/Components/Sprite.xsd
+++ b/resources/Schema/Components/Sprite.xsd
@@ -24,6 +24,12 @@
 				<xs:element name="DepthSort" type="t:bool" minOccurs="0">
 					<xs:annotation><xs:documentation>Whether the sprite should be sorted with depth or not. Only use false for textures that are on HUD</xs:documentation></xs:annotation>
 				</xs:element>
+				<xs:element name="KeepRatioX" type="t:bool" minOccurs="0">
+					<xs:annotation><xs:documentation>Wether the sprite should repeat in x instead of stretch when scaled.</xs:documentation></xs:annotation>
+				</xs:element>
+				<xs:element name="KeepRatioY" type="t:bool" minOccurs="0">
+					<xs:annotation><xs:documentation>Wether the sprite should repeat in y instead of stretch when scaled.</xs:documentation></xs:annotation>
+				</xs:element>
 				<xs:element name="BlurBackground" type="t:bool" minOccurs="0">
 					<xs:annotation><xs:documentation>Wether the background should be blurred begind this sprite.</xs:documentation></xs:annotation>
 				</xs:element>

--- a/resources/Schema/Components/Sprite.xsd
+++ b/resources/Schema/Components/Sprite.xsd
@@ -30,6 +30,9 @@
 				<xs:element name="KeepRatioY" type="t:bool" minOccurs="0">
 					<xs:annotation><xs:documentation>Wether the sprite should repeat in y instead of stretch when scaled.</xs:documentation></xs:annotation>
 				</xs:element>
+				<xs:element name="KeepRatio" type="t:bool" minOccurs="0">
+					<xs:annotation><xs:documentation>Keep a 1:1 ratio between X and Y.</xs:documentation></xs:annotation>
+				</xs:element>
 				<xs:element name="BlurBackground" type="t:bool" minOccurs="0">
 					<xs:annotation><xs:documentation>Wether the background should be blurred begind this sprite.</xs:documentation></xs:annotation>
 				</xs:element>

--- a/resources/Schema/Components/Sprite.xsd
+++ b/resources/Schema/Components/Sprite.xsd
@@ -9,14 +9,17 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:all>
+				<xs:element name="Model" type="t:string" minOccurs="0">
+					<xs:annotation><xs:documentation>The model the sprite will use.</xs:documentation></xs:annotation>
+				</xs:element>
 				<xs:element name="DiffuseTexture" type="t:string" minOccurs="0">
-					<xs:annotation><xs:documentation>Diffuse Texture file</xs:documentation></xs:annotation>
+					<xs:annotation><xs:documentation>Diffuse Texture file.</xs:documentation></xs:annotation>
 				</xs:element>
 				<xs:element name="GlowMap" type="t:string" minOccurs="0">
-					<xs:annotation><xs:documentation>GlowMap file</xs:documentation></xs:annotation>
+					<xs:annotation><xs:documentation>GlowMap file.</xs:documentation></xs:annotation>
 				</xs:element>
 				<xs:element name="Color" type="t:Color" minOccurs="0">
-					<xs:annotation><xs:documentation>Color tint</xs:documentation></xs:annotation>
+					<xs:annotation><xs:documentation>Color tint.</xs:documentation></xs:annotation>
 				</xs:element>
 				<xs:element name="Visible" type="t:bool" minOccurs="0">
 					<xs:annotation><xs:documentation>Whether the model is visible or not</xs:documentation></xs:annotation>
@@ -32,6 +35,9 @@
 				</xs:element>
 				<xs:element name="KeepRatio" type="t:bool" minOccurs="0">
 					<xs:annotation><xs:documentation>Keep a 1:1 ratio between X and Y.</xs:documentation></xs:annotation>
+				</xs:element>
+				<xs:element name="Linear" type="t:bool" minOccurs="0">
+					<xs:annotation><xs:documentation>If it should use Linear or Nearest sampling method.</xs:documentation></xs:annotation>
 				</xs:element>
 				<xs:element name="BlurBackground" type="t:bool" minOccurs="0">
 					<xs:annotation><xs:documentation>Wether the background should be blurred begind this sprite.</xs:documentation></xs:annotation>

--- a/resources/Schema/Entities/OverwatchCamera.xml
+++ b/resources/Schema/Entities/OverwatchCamera.xml
@@ -8,7 +8,7 @@
     </c:RaptorCopter>
     <c:Transform>
       <Position X="0" Y="-4" Z="0"/>
-      <Orientation X="0" Y="55.3495064" Z="0"/>
+      <Orientation X="0" Y="58.3794823" Z="0"/>
     </c:Transform>
   </Components>
 
@@ -34,13 +34,49 @@
                 </c:Transform>
               </Components>
               <Children>
+                <Entity name="AssaultClassPick">
+                  <Components>
+                    <c:Button/>
+                    <c:Sprite>
+                      <DepthSort>false</DepthSort>
+                      <Model>Models/Core/UnitQuad.mesh</Model>
+                      <GlowMap></GlowMap>
+                      <DiffuseTexture>Textures/Icons/Classes/Assault-01.png</DiffuseTexture>
+                    </c:Sprite>
+                    <c:InputCmdButton>
+                      <Command>PickClass</Command>
+                      <PressValue>1</PressValue>
+                    </c:InputCmdButton>
+                    <c:Transform>
+                      <Position X="-0.150000006" Y="-0.0500000007" Z="0"/>
+                      <Scale X="0.0799999982" Y="0.0799999982" Z="1"/>
+                    </c:Transform>
+                  </Components>
+                  <Children>
+                    <Entity name="AssaultText">
+                      <Components>
+                        <c:Text>
+                          <Content>Assault</Content>
+                          <Resource>Fonts/DroidSans.ttf,64</Resource>
+                          <Color A="1" B="0" G="1" R="0.784313738"/>
+                        </c:Text>
+                        <c:Transform>
+                          <Position X="0" Y="0.800000012" Z="0"/>
+                          <Scale X="0.310000002" Y="0.310000002" Z="1"/>
+                        </c:Transform>
+                      </Components>
+                      <Children/>
+                    </Entity>
+                  </Children>
+                </Entity>
                 <Entity name="DefenderClassPick">
                   <Components>
                     <c:Button/>
                     <c:Sprite>
-                      <DiffuseTexture>Textures/Icons/Classes/Defender-01.png</DiffuseTexture>
-                      <GlowMap></GlowMap>
                       <DepthSort>false</DepthSort>
+                      <Model>Models/Core/UnitQuad.mesh</Model>
+                      <GlowMap></GlowMap>
+                      <DiffuseTexture>Textures/Icons/Classes/Defender-01.png</DiffuseTexture>
                     </c:Sprite>
                     <c:InputCmdButton>
                       <Command>PickClass</Command>
@@ -72,9 +108,10 @@
                   <Components>
                     <c:Button/>
                     <c:Sprite>
-                      <DiffuseTexture>Textures/Icons/Classes/Sniper-01.png</DiffuseTexture>
-                      <GlowMap></GlowMap>
                       <DepthSort>false</DepthSort>
+                      <Model>Models/Core/UnitQuad.mesh</Model>
+                      <GlowMap></GlowMap>
+                      <DiffuseTexture>Textures/Icons/Classes/Sniper-01.png</DiffuseTexture>
                     </c:Sprite>
                     <c:InputCmdButton>
                       <Command>PickClass</Command>
@@ -90,40 +127,6 @@
                       <Components>
                         <c:Text>
                           <Content>Sniper</Content>
-                          <Resource>Fonts/DroidSans.ttf,64</Resource>
-                          <Color A="1" B="0" G="1" R="0.784313738"/>
-                        </c:Text>
-                        <c:Transform>
-                          <Position X="0" Y="0.800000012" Z="0"/>
-                          <Scale X="0.310000002" Y="0.310000002" Z="1"/>
-                        </c:Transform>
-                      </Components>
-                      <Children/>
-                    </Entity>
-                  </Children>
-                </Entity>
-                <Entity name="AssaultClassPick">
-                  <Components>
-                    <c:Button/>
-                    <c:Sprite>
-                      <DiffuseTexture>Textures/Icons/Classes/Assault-01.png</DiffuseTexture>
-                      <GlowMap></GlowMap>
-                      <DepthSort>false</DepthSort>
-                    </c:Sprite>
-                    <c:InputCmdButton>
-                      <Command>PickClass</Command>
-                      <PressValue>1</PressValue>
-                    </c:InputCmdButton>
-                    <c:Transform>
-                      <Position X="-0.150000006" Y="-0.0500000007" Z="0"/>
-                      <Scale X="0.0799999982" Y="0.0799999982" Z="1"/>
-                    </c:Transform>
-                  </Components>
-                  <Children>
-                    <Entity name="AssaultText">
-                      <Components>
-                        <c:Text>
-                          <Content>Assault</Content>
                           <Resource>Fonts/DroidSans.ttf,64</Resource>
                           <Color A="1" B="0" G="1" R="0.784313738"/>
                         </c:Text>
@@ -154,9 +157,10 @@
                   <Components>
                     <c:Button/>
                     <c:Sprite>
-                      <DiffuseTexture>Textures/Core/UnitHexagon.png</DiffuseTexture>
-                      <GlowMap></GlowMap>
                       <DepthSort>false</DepthSort>
+                      <Model>Models/Core/UnitQuad.mesh</Model>
+                      <GlowMap></GlowMap>
+                      <DiffuseTexture>Textures/Core/UnitHexagon.png</DiffuseTexture>
                       <Color A="1" B="0" G="1" R="0.509803951"/>
                     </c:Sprite>
                     <c:InputCmdButton>
@@ -232,9 +236,10 @@
                   <Components>
                     <c:Button/>
                     <c:Sprite>
-                      <DiffuseTexture>Textures/Core/UnitHexagon.png</DiffuseTexture>
-                      <GlowMap></GlowMap>
                       <DepthSort>false</DepthSort>
+                      <Model>Models/Core/UnitQuad.mesh</Model>
+                      <GlowMap></GlowMap>
+                      <DiffuseTexture>Textures/Core/UnitHexagon.png</DiffuseTexture>
                       <Color A="1" B="0" G="1" R="0.509803951"/>
                     </c:Sprite>
                     <c:InputCmdButton>
@@ -266,10 +271,11 @@
                   <Components>
                     <c:Button/>
                     <c:Sprite>
-                      <DiffuseTexture>Textures/Core/UnitHexagon.png</DiffuseTexture>
+                      <Model>Models/Core/UnitQuad.mesh</Model>
                       <GlowMap></GlowMap>
-                      <DepthSort>false</DepthSort>
+                      <DiffuseTexture>Textures/Core/UnitHexagon.png</DiffuseTexture>
                       <Color A="1" B="0" G="0.294117659" R="0.980392158"/>
+                      <Linear>true</Linear>
                     </c:Sprite>
                     <c:InputCmdButton>
                       <Command>PickTeam</Command>
@@ -300,10 +306,12 @@
                   <Components>
                     <c:Button/>
                     <c:Sprite>
-                      <DiffuseTexture>Textures/Core/UnitHexagon.png</DiffuseTexture>
-                      <GlowMap></GlowMap>
                       <DepthSort>false</DepthSort>
+                      <Model>Models/Core/UnitQuad.mesh</Model>
+                      <GlowMap></GlowMap>
+                      <DiffuseTexture>Textures/Core/UnitHexagon.png</DiffuseTexture>
                       <Color A="1" B="0.980392158" G="0.294117659" R="0"/>
+                      <Linear>true</Linear>
                     </c:Sprite>
                     <c:InputCmdButton>
                       <Command>PickTeam</Command>
@@ -334,9 +342,10 @@
                   <Components>
                     <c:Button/>
                     <c:Sprite>
-                      <DiffuseTexture>Textures/Core/UnitHexagon.png</DiffuseTexture>
-                      <GlowMap></GlowMap>
                       <DepthSort>false</DepthSort>
+                      <Model>Models/Core/UnitQuad.mesh</Model>
+                      <GlowMap></GlowMap>
+                      <DiffuseTexture>Textures/Core/UnitHexagon.png</DiffuseTexture>
                       <Color A="1" B="0" G="1" R="0.509803951"/>
                       <Visible>false</Visible>
                     </c:Sprite>
@@ -422,9 +431,10 @@
                     <Entity name="BackgroundHexagon">
                       <Components>
                         <c:Sprite>
-                          <DiffuseTexture>Textures/Core/UnitHexagon.png</DiffuseTexture>
-                          <GlowMap></GlowMap>
                           <DepthSort>false</DepthSort>
+                          <Model>Models/Core/UnitQuad.mesh</Model>
+                          <GlowMap></GlowMap>
+                          <DiffuseTexture>Textures/Core/UnitHexagon.png</DiffuseTexture>
                           <Color A="0.300000012" B="1" G="1" R="1"/>
                         </c:Sprite>
                         <c:Transform>
@@ -441,9 +451,10 @@
                               <CapturePointNumber>3</CapturePointNumber>
                             </c:CapturePointHUD>
                             <c:Sprite>
-                              <DiffuseTexture>Textures/Core/UnitHexagon_Rotated.png</DiffuseTexture>
-                              <GlowMap></GlowMap>
                               <DepthSort>false</DepthSort>
+                              <Model>Models/Core/UnitQuad.mesh</Model>
+                              <GlowMap></GlowMap>
+                              <DiffuseTexture>Textures/Core/UnitHexagon_Rotated.png</DiffuseTexture>
                             </c:Sprite>
                             <c:Transform>
                               <Position X="0" Y="0" Z="0.00999999978"/>
@@ -458,9 +469,10 @@
                     <Entity name="BackgroundHexagon">
                       <Components>
                         <c:Sprite>
-                          <DiffuseTexture>Textures/Core/UnitHexagon.png</DiffuseTexture>
-                          <GlowMap></GlowMap>
                           <DepthSort>false</DepthSort>
+                          <Model>Models/Core/UnitQuad.mesh</Model>
+                          <GlowMap></GlowMap>
+                          <DiffuseTexture>Textures/Core/UnitHexagon.png</DiffuseTexture>
                           <Color A="0.699999988" B="1" G="0.200000003" R="0"/>
                         </c:Sprite>
                         <c:Transform>
@@ -477,9 +489,10 @@
                               <CapturePointNumber>4</CapturePointNumber>
                             </c:CapturePointHUD>
                             <c:Sprite>
-                              <DiffuseTexture>Textures/Core/UnitHexagon_Rotated.png</DiffuseTexture>
-                              <GlowMap></GlowMap>
                               <DepthSort>false</DepthSort>
+                              <Model>Models/Core/UnitQuad.mesh</Model>
+                              <GlowMap></GlowMap>
+                              <DiffuseTexture>Textures/Core/UnitHexagon_Rotated.png</DiffuseTexture>
                             </c:Sprite>
                             <c:Transform>
                               <Position X="0" Y="0" Z="0.00999999978"/>
@@ -494,9 +507,10 @@
                     <Entity name="BackgroundHexagon">
                       <Components>
                         <c:Sprite>
-                          <DiffuseTexture>Textures/Core/UnitHexagon.png</DiffuseTexture>
-                          <GlowMap></GlowMap>
                           <DepthSort>false</DepthSort>
+                          <Model>Models/Core/UnitQuad.mesh</Model>
+                          <GlowMap></GlowMap>
+                          <DiffuseTexture>Textures/Core/UnitHexagon.png</DiffuseTexture>
                           <Color A="0.300000012" B="1" G="1" R="1"/>
                         </c:Sprite>
                         <c:Transform>
@@ -513,9 +527,10 @@
                               <CapturePointNumber>2</CapturePointNumber>
                             </c:CapturePointHUD>
                             <c:Sprite>
-                              <DiffuseTexture>Textures/Core/UnitHexagon_Rotated.png</DiffuseTexture>
-                              <GlowMap></GlowMap>
                               <DepthSort>false</DepthSort>
+                              <Model>Models/Core/UnitQuad.mesh</Model>
+                              <GlowMap></GlowMap>
+                              <DiffuseTexture>Textures/Core/UnitHexagon_Rotated.png</DiffuseTexture>
                             </c:Sprite>
                             <c:Transform>
                               <Position X="0" Y="0" Z="0.00999999978"/>
@@ -530,9 +545,10 @@
                     <Entity name="BackgroundHexagon">
                       <Components>
                         <c:Sprite>
-                          <DiffuseTexture>Textures/Core/UnitHexagon.png</DiffuseTexture>
-                          <GlowMap></GlowMap>
                           <DepthSort>false</DepthSort>
+                          <Model>Models/Core/UnitQuad.mesh</Model>
+                          <GlowMap></GlowMap>
+                          <DiffuseTexture>Textures/Core/UnitHexagon.png</DiffuseTexture>
                           <Color A="0.300000012" B="1" G="1" R="1"/>
                         </c:Sprite>
                         <c:Transform>
@@ -550,9 +566,10 @@
                               <CapturePointNumber>1</CapturePointNumber>
                             </c:CapturePointHUD>
                             <c:Sprite>
-                              <DiffuseTexture>Textures/Core/UnitHexagon_Rotated.png</DiffuseTexture>
-                              <GlowMap></GlowMap>
                               <DepthSort>false</DepthSort>
+                              <Model>Models/Core/UnitQuad.mesh</Model>
+                              <GlowMap></GlowMap>
+                              <DiffuseTexture>Textures/Core/UnitHexagon_Rotated.png</DiffuseTexture>
                             </c:Sprite>
                             <c:Transform>
                               <Position X="0" Y="0" Z="0.00999999978"/>
@@ -567,9 +584,10 @@
                     <Entity name="BackgroundHexagon">
                       <Components>
                         <c:Sprite>
-                          <DiffuseTexture>Textures/Core/UnitHexagon.png</DiffuseTexture>
-                          <GlowMap></GlowMap>
                           <DepthSort>false</DepthSort>
+                          <Model>Models/Core/UnitQuad.mesh</Model>
+                          <GlowMap></GlowMap>
+                          <DiffuseTexture>Textures/Core/UnitHexagon.png</DiffuseTexture>
                           <Color A="0.699999988" B="0" G="0" R="1"/>
                         </c:Sprite>
                         <c:Transform>
@@ -584,9 +602,10 @@
                             </c:Fill>
                             <c:CapturePointHUD/>
                             <c:Sprite>
-                              <DiffuseTexture>Textures/Core/UnitHexagon_Rotated.png</DiffuseTexture>
-                              <GlowMap></GlowMap>
                               <DepthSort>false</DepthSort>
+                              <Model>Models/Core/UnitQuad.mesh</Model>
+                              <GlowMap></GlowMap>
+                              <DiffuseTexture>Textures/Core/UnitHexagon_Rotated.png</DiffuseTexture>
                             </c:Sprite>
                             <c:Transform>
                               <Position X="0" Y="0" Z="0.00999999978"/>
@@ -604,9 +623,10 @@
                   <Components>
                     <c:Button/>
                     <c:Sprite>
-                      <DiffuseTexture>Textures/Core/UnitHexagon.png</DiffuseTexture>
-                      <GlowMap></GlowMap>
                       <DepthSort>false</DepthSort>
+                      <Model>Models/Core/UnitQuad.mesh</Model>
+                      <GlowMap></GlowMap>
+                      <DiffuseTexture>Textures/Core/UnitHexagon.png</DiffuseTexture>
                       <Color A="1" B="0" G="1" R="0.509803951"/>
                     </c:Sprite>
                     <c:InputCmdButton>
@@ -651,9 +671,10 @@
                   <Components>
                     <c:Button/>
                     <c:Sprite>
-                      <DiffuseTexture>Textures/Core/UnitHexagon.png</DiffuseTexture>
-                      <GlowMap></GlowMap>
                       <DepthSort>false</DepthSort>
+                      <Model>Models/Core/UnitQuad.mesh</Model>
+                      <GlowMap></GlowMap>
+                      <DiffuseTexture>Textures/Core/UnitHexagon.png</DiffuseTexture>
                       <Color A="1" B="0" G="1" R="0.509803951"/>
                     </c:Sprite>
                     <c:InputCmdButton>

--- a/resources/Shaders/CombineGaussianTexture.frag.glsl
+++ b/resources/Shaders/CombineGaussianTexture.frag.glsl
@@ -1,6 +1,7 @@
 #version 430
 
 layout (binding = 0) uniform sampler2D Texture;
+uniform int MaxMipMap;
 
 
 in VertexData{
@@ -11,12 +12,19 @@ out vec4 fragmentColor;
 
 void main()
 {
+	vec4 result = vec4(0.0, 0.0, 0.0, 0.0);
+
+	for(int i = 0; i < MaxMipMap; i++) {
+		result += textureLod(Texture, Input.TextureCoordinate, i);
+	}
+	fragmentColor = result;
+/*
 	vec4 texel0 = textureLod(Texture, Input.TextureCoordinate, 0);
 	vec4 texel1 = textureLod(Texture, Input.TextureCoordinate, 1);
 	vec4 texel2 = textureLod(Texture, Input.TextureCoordinate, 2);
 	vec4 texel3 = textureLod(Texture, Input.TextureCoordinate, 3);
+	vec4 texel4 = textureLod(Texture, Input.TextureCoordinate, 4);
 
-	fragmentColor = texel0 + texel1 + texel2 + texel3;
+	fragmentColor = texel0 + texel1 + texel2 + texel3 + texel4;*/
+	
 }
-
-

--- a/resources/Shaders/CombineGaussianTexture.frag.glsl
+++ b/resources/Shaders/CombineGaussianTexture.frag.glsl
@@ -18,13 +18,4 @@ void main()
 		result += textureLod(Texture, Input.TextureCoordinate, i);
 	}
 	fragmentColor = result;
-/*
-	vec4 texel0 = textureLod(Texture, Input.TextureCoordinate, 0);
-	vec4 texel1 = textureLod(Texture, Input.TextureCoordinate, 1);
-	vec4 texel2 = textureLod(Texture, Input.TextureCoordinate, 2);
-	vec4 texel3 = textureLod(Texture, Input.TextureCoordinate, 3);
-	vec4 texel4 = textureLod(Texture, Input.TextureCoordinate, 4);
-
-	fragmentColor = texel0 + texel1 + texel2 + texel3 + texel4;*/
-	
 }

--- a/resources/Shaders/CombineGaussianTexture.frag.glsl
+++ b/resources/Shaders/CombineGaussianTexture.frag.glsl
@@ -1,0 +1,22 @@
+#version 430
+
+layout (binding = 0) uniform sampler2D Texture;
+
+
+in VertexData{
+	vec2 TextureCoordinate;
+}Input;
+
+out vec4 fragmentColor;
+
+void main()
+{
+	vec4 texel0 = textureLod(Texture, Input.TextureCoordinate, 0);
+	vec4 texel1 = textureLod(Texture, Input.TextureCoordinate, 1);
+	vec4 texel2 = textureLod(Texture, Input.TextureCoordinate, 2);
+	vec4 texel3 = textureLod(Texture, Input.TextureCoordinate, 3);
+
+	fragmentColor = texel0 + texel1 + texel2 + texel3;
+}
+
+

--- a/resources/Shaders/CombineGaussianTexture.vert.glsl
+++ b/resources/Shaders/CombineGaussianTexture.vert.glsl
@@ -1,0 +1,13 @@
+#version 430
+
+layout (location = 0) in vec3 Position;
+
+out VertexData{
+	vec2 TextureCoordinate;
+}Output;
+
+void main()
+{
+	gl_Position = vec4(Position, 1.0);
+	Output.TextureCoordinate = (vec2(Position) + 1) / 2;
+}

--- a/resources/Shaders/Gaussian_horiz.frag.glsl
+++ b/resources/Shaders/Gaussian_horiz.frag.glsl
@@ -2,6 +2,7 @@
 #extension GL_EXT_gpu_shader4 : enable
 
 layout (binding = 0) uniform sampler2D Texture;
+uniform int Lod;
 
 in VertexData{
 	vec2 TextureCoordinate;
@@ -10,12 +11,14 @@ in VertexData{
 out vec4 fragmentColor;
 
 uniform float weight[5] = float[](0.227027, 0.1945946, 0.1216216, 0.054054, 0.016216);
+//uniform float weight[3] = float[](0.265495, 0.226535, 0.140718);
 
 void main()
 {
-	vec2 tex_offset = 1.0 / textureSize2D(Texture, 0);
+	vec2 tex_offset = 1.0 / textureSize(Texture, Lod);
 	vec3 center = texture(Texture, Input.TextureCoordinate).rgb;
 	vec3 result = center * weight[0];
+
 	for(int i = 1; i < 5; ++i) {
 		vec4 eastFragments = texture(Texture, Input.TextureCoordinate + vec2(tex_offset.x * i, 0.0));
 		vec4 westFragments = texture(Texture, Input.TextureCoordinate - vec2(tex_offset.x * i, 0.0));

--- a/resources/Shaders/Gaussian_vert.frag.glsl
+++ b/resources/Shaders/Gaussian_vert.frag.glsl
@@ -2,6 +2,7 @@
 #extension GL_EXT_gpu_shader4 : enable
 
 layout (binding = 0) uniform sampler2D Texture;
+uniform int Lod;
 
 in VertexData{
 	vec2 TextureCoordinate;
@@ -10,12 +11,14 @@ in VertexData{
 out vec4 fragmentColor;
 
 uniform float weight[5] = float[](0.227027, 0.1945946, 0.1216216, 0.054054, 0.016216);
+//uniform float weight[3] = float[](0.265495, 0.226535, 0.140718);
 
 void main()
 {
-	vec2 tex_offset = 1.0 / textureSize2D(Texture, 0);
+	vec2 tex_offset = 1.0 / textureSize(Texture, Lod);
 	vec3 center = texture(Texture, Input.TextureCoordinate).rgb;
 	vec3 result = center * weight[0];
+
     for(int i = 1; i < 5; ++i) {
     	vec4 northFragments = texture(Texture, Input.TextureCoordinate + vec2(0.0, tex_offset.y * i));
     	vec4 southFragments = texture(Texture, Input.TextureCoordinate - vec2(0.0, tex_offset.y * i));

--- a/resources/Shaders/Sprite.frag.glsl
+++ b/resources/Shaders/Sprite.frag.glsl
@@ -3,6 +3,8 @@
 uniform vec4 Color;
 uniform vec4 FillColor;
 uniform float FillPercentage;
+uniform float ScaleX;
+uniform float ScaleY;
 uniform mat4 P;
 
 layout (binding = 1) uniform sampler2D DiffuseTexture;
@@ -21,15 +23,16 @@ out vec4 bloomColor;
 
 void main()
 {
-	vec4 diffuseTexel = texture2D(DiffuseTexture, Input.TextureCoordinate);
-	vec4 glowTexel = texture2D(GlowMapTexture, Input.TextureCoordinate);
+	vec4 diffuseTexel = texture2D(DiffuseTexture, vec2(Input.TextureCoordinate.x*ScaleX, Input.TextureCoordinate.y*ScaleY));
+	vec4 glowTexel = texture2D(GlowMapTexture, vec2(Input.TextureCoordinate.x*ScaleX, Input.TextureCoordinate.y*ScaleY));
 
 	vec4 color_result = Color * diffuseTexel;
 
 	float pos = ((P * vec4(Input.Position, 1)).y + 1.0)/2.0;
-	if(pos <= FillPercentage) {
-		color_result = FillColor*diffuseTexel.a;
-	}
+	float fillResult = floor(pos*FillPercentage);
+
+	color_result = FillColor*diffuseTexel.a*fillResult + color_result*(1-fillResult);
+
 	sceneColor = vec4(color_result.xyz, clamp(color_result.a, 0, 1));
 
 	//bloomColor = vec4(clamp((glowTexel.xyz*3) - 1.0, 0, 100), 1.0);

--- a/src/Engine/Rendering/BlurHUD.cpp
+++ b/src/Engine/Rendering/BlurHUD.cpp
@@ -97,14 +97,14 @@ void BlurHUD::ClearBuffer()
     glClearStencil(0x00);
     glStencilMask(~0);
     glDisable(GL_SCISSOR_TEST);
-    glClear(GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+    glClear(GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     m_GaussianFrameBuffer_horiz.Unbind();
     m_GaussianFrameBuffer_vert.Bind();
     glClearColor(0.f, 0.f, 0.f, 0.f);
     glClearStencil(0x00);
     glStencilMask(~0);
     glDisable(GL_SCISSOR_TEST);
-    glClear(GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+    glClear(GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     m_GaussianFrameBuffer_vert.Unbind();
 
     m_CombinedTextureBuffer.Bind();
@@ -211,12 +211,16 @@ void BlurHUD::FillStencil(RenderScene& scene)
     RenderState state;
 
     state.BindFramebuffer(m_GaussianFrameBuffer_horiz.GetHandle());
-    state.Disable(GL_DEPTH_TEST);
+    state.Enable(GL_DEPTH_TEST);
     state.Enable(GL_CULL_FACE);
     state.Enable(GL_STENCIL_TEST);
     state.StencilFunc(GL_ALWAYS, 1, 0xFF);
     state.StencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
     state.StencilMask(0xFF);
+
+    state.AlphaFunc(GL_GEQUAL, 0.95f);
+    state.Enable(GL_ALPHA_TEST);
+
     glViewport(0, 0, m_Renderer->GetViewportSize().Width/m_BlurQuality, m_Renderer->GetViewportSize().Height/m_BlurQuality);
 
     m_FillDepthStencilProgram->Bind();

--- a/src/Engine/Rendering/DrawBloomPass.cpp
+++ b/src/Engine/Rendering/DrawBloomPass.cpp
@@ -200,8 +200,6 @@ void DrawBloomPass::GaussianLodPass(GLuint mipMap, GLuint texture)
         glActiveTexture(GL_TEXTURE0);
         glBindTexture(GL_TEXTURE_2D, m_GaussianTexture_horiz);
 
-        glBindVertexArray(m_ScreenQuad->VAO);
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_ScreenQuad->ElementBuffer);
         glDrawElementsBaseVertex(GL_TRIANGLES, m_ScreenQuad->MaterialGroups()[0].material->EndIndex - m_ScreenQuad->MaterialGroups()[0].material->StartIndex +1
             , GL_UNSIGNED_INT, 0, m_ScreenQuad->MaterialGroups()[0].material->StartIndex);
         //horizontal pass
@@ -213,8 +211,6 @@ void DrawBloomPass::GaussianLodPass(GLuint mipMap, GLuint texture)
         glActiveTexture(GL_TEXTURE0);
         glBindTexture(GL_TEXTURE_2D, m_GaussianTexture_vert);
 
-        glBindVertexArray(m_ScreenQuad->VAO);
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_ScreenQuad->ElementBuffer);
         glDrawElementsBaseVertex(GL_TRIANGLES, m_ScreenQuad->MaterialGroups()[0].material->EndIndex - m_ScreenQuad->MaterialGroups()[0].material->StartIndex +1
             , GL_UNSIGNED_INT, 0, m_ScreenQuad->MaterialGroups()[0].material->StartIndex);
         m_GaussianFrameBuffer_horiz[mipMap].Unbind();
@@ -227,8 +223,7 @@ void DrawBloomPass::GaussianLodPass(GLuint mipMap, GLuint texture)
 
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, m_GaussianTexture_horiz);
-    glBindVertexArray(m_ScreenQuad->VAO);
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_ScreenQuad->ElementBuffer);
+
     glDrawElementsBaseVertex(GL_TRIANGLES, m_ScreenQuad->MaterialGroups()[0].material->EndIndex - m_ScreenQuad->MaterialGroups()[0].material->StartIndex +1
         , GL_UNSIGNED_INT, 0, m_ScreenQuad->MaterialGroups()[0].material->StartIndex);
 

--- a/src/Engine/Rendering/DrawFinalPass.cpp
+++ b/src/Engine/Rendering/DrawFinalPass.cpp
@@ -302,6 +302,8 @@ void DrawFinalPass::Draw(RenderScene& scene, BlurHUD* blurHUDPass)
 	GLERROR("TransparentObjects");
 	//state->BlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     stateSprite->Enable(GL_DEPTH_TEST);
+    stateSprite->AlphaFunc(GL_GEQUAL, 0.05f);
+    stateSprite->Enable(GL_ALPHA_TEST);
 	DrawSprites(scene.Jobs.SpriteJob, scene);
 	GLERROR("SpriteJobs");
 

--- a/src/Engine/Rendering/DrawFinalPass.cpp
+++ b/src/Engine/Rendering/DrawFinalPass.cpp
@@ -311,8 +311,8 @@ void DrawFinalPass::Draw(RenderScene& scene, BlurHUD* blurHUDPass)
 	GLERROR("TransparentObjects");
 	//state->BlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     stateSprite->Enable(GL_DEPTH_TEST);
-    stateSprite->AlphaFunc(GL_GEQUAL, 0.05f);
-    stateSprite->Enable(GL_ALPHA_TEST);
+    //stateSprite->AlphaFunc(GL_GEQUAL, 0.05f);
+    //stateSprite->Enable(GL_ALPHA_TEST);
 	DrawSprites(scene.Jobs.SpriteJob, scene);
 	GLERROR("SpriteJobs");
 

--- a/src/Engine/Rendering/DrawFinalPass.cpp
+++ b/src/Engine/Rendering/DrawFinalPass.cpp
@@ -1291,11 +1291,17 @@ void DrawFinalPass::DrawSprites(std::list<std::shared_ptr<RenderJob>>&jobs, Rend
             glActiveTexture(GL_TEXTURE1);
             if (spriteJob->DiffuseTexture != nullptr) {
                 glBindTexture(GL_TEXTURE_2D, spriteJob->DiffuseTexture->m_Texture);
+                if (spriteJob->Linear) {
+                    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+                    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+                } else {
+                    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST_MIPMAP_NEAREST);
+                    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+                }
+
             } else {
                 glBindTexture(GL_TEXTURE_2D, m_ErrorTexture->m_Texture);
             }
-
-
 
             glActiveTexture(GL_TEXTURE2);
             if (spriteJob->IncandescenceTexture != nullptr) {

--- a/src/Engine/Rendering/DrawFinalPass.cpp
+++ b/src/Engine/Rendering/DrawFinalPass.cpp
@@ -1271,14 +1271,15 @@ void DrawFinalPass::DrawSprites(std::list<std::shared_ptr<RenderJob>>&jobs, Rend
 
 	glUniformMatrix4fv(glGetUniformLocation(shaderHandle, "P"), 1, GL_FALSE, glm::value_ptr(scene.Camera->ProjectionMatrix()));
 	glUniform3fv(glGetUniformLocation(shaderHandle, "CameraPos"), 1, glm::value_ptr(scene.Camera->Position()));
+    RenderState* jobState = new RenderState();
+
 
     for(auto& job : jobs) {
         auto spriteJob = std::dynamic_pointer_cast<SpriteJob>(job);
-        RenderState jobState;
 
         if (spriteJob) {
             if(spriteJob->Depth == 0) {
-                jobState.Disable(GL_DEPTH_TEST);
+                jobState->Disable(GL_DEPTH_TEST);
             }
             glUniformMatrix4fv(glGetUniformLocation(shaderHandle, "PVM"), 1, GL_FALSE, glm::value_ptr(scene.Camera->ProjectionMatrix() * scene.Camera->ViewMatrix() * spriteJob->Matrix));
             glUniform4fv(glGetUniformLocation(shaderHandle, "Color"), 1, glm::value_ptr(spriteJob->Color));
@@ -1294,6 +1295,8 @@ void DrawFinalPass::DrawSprites(std::list<std::shared_ptr<RenderJob>>&jobs, Rend
                 glBindTexture(GL_TEXTURE_2D, m_ErrorTexture->m_Texture);
             }
 
+
+
             glActiveTexture(GL_TEXTURE2);
             if (spriteJob->IncandescenceTexture != nullptr) {
                 glBindTexture(GL_TEXTURE_2D, spriteJob->IncandescenceTexture->m_Texture);
@@ -1307,6 +1310,7 @@ void DrawFinalPass::DrawSprites(std::list<std::shared_ptr<RenderJob>>&jobs, Rend
             glDrawElements(GL_TRIANGLES, spriteJob->EndIndex - spriteJob->StartIndex + 1, GL_UNSIGNED_INT, (void*)(spriteJob->StartIndex*sizeof(unsigned int)));
         }
     }
+    delete jobState;
    // m_SpriteProgram->Unbind();
 }
 

--- a/src/Engine/Rendering/DrawFinalPass.cpp
+++ b/src/Engine/Rendering/DrawFinalPass.cpp
@@ -32,9 +32,9 @@ void DrawFinalPass::InitializeTextures()
 
 void DrawFinalPass::InitializeFrameBuffers()
 {
-	CommonFunctions::GenerateTexture(&m_SceneTexture, GL_CLAMP_TO_EDGE, GL_LINEAR, glm::vec2(m_Renderer->GetViewportSize().Width, m_Renderer->GetViewportSize().Height), GL_RGB16F, GL_RGB, GL_FLOAT);
+	CommonFunctions::GenerateTexture(&m_SceneTexture, GL_CLAMP_TO_BORDER, GL_LINEAR, glm::vec2(m_Renderer->GetViewportSize().Width, m_Renderer->GetViewportSize().Height), GL_RGB16F, GL_RGB, GL_FLOAT);
     //GenerateTexture(&m_BloomTexture, GL_CLAMP_TO_EDGE, GL_LINEAR, glm::vec2(m_Renderer->GetViewPortSize().Width, m_Renderer->GetViewPortSize().Height), GL_RGB16F, GL_RGB, GL_FLOAT);
-	CommonFunctions::GenerateTexture(&m_BloomTexture, GL_CLAMP_TO_EDGE, GL_LINEAR, glm::vec2(m_Renderer->GetViewportSize().Width, m_Renderer->GetViewportSize().Height), GL_RGB16F, GL_RGB, GL_FLOAT);
+	CommonFunctions::GenerateTexture(&m_BloomTexture, GL_CLAMP_TO_BORDER, GL_LINEAR, glm::vec2(m_Renderer->GetViewportSize().Width, m_Renderer->GetViewportSize().Height), GL_RGB16F, GL_RGB, GL_FLOAT);
     //GenerateMipMapTexture(&m_BloomTexture, GL_CLAMP_TO_EDGE, glm::vec2(m_Renderer->GetViewPortSize().Width, m_Renderer->GetViewPortSize().Height), GL_RGB16F, GL_FLOAT, 4);
     //GenerateTexture(&m_StencilTexture, GL_CLAMP_TO_EDGE, GL_LINEAR, glm::vec2(m_Renderer->GetViewportSize().Width, m_Renderer->GetViewportSize().Height), GL_STENCIL, GL_STENCIL_INDEX8, GL_INT);
 
@@ -345,8 +345,8 @@ void DrawFinalPass::OnWindowResize()
     //InitializeFrameBuffers();
 	CommonFunctions::GenerateTexture(&m_DepthBuffer, GL_CLAMP_TO_BORDER, GL_NEAREST,
 		glm::vec2(m_Renderer->GetViewportSize().Width, m_Renderer->GetViewportSize().Height), GL_DEPTH24_STENCIL8, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8);
-    CommonFunctions::GenerateTexture(&m_SceneTexture, GL_CLAMP_TO_EDGE, GL_LINEAR, glm::vec2(m_Renderer->GetViewportSize().Width, m_Renderer->GetViewportSize().Height), GL_RGB16F, GL_RGB, GL_FLOAT);
-	CommonFunctions::GenerateTexture(&m_BloomTexture, GL_CLAMP_TO_EDGE, GL_LINEAR, glm::vec2(m_Renderer->GetViewportSize().Width, m_Renderer->GetViewportSize().Height), GL_RGB16F, GL_RGB, GL_FLOAT);
+    CommonFunctions::GenerateTexture(&m_SceneTexture, GL_CLAMP_TO_BORDER, GL_LINEAR, glm::vec2(m_Renderer->GetViewportSize().Width, m_Renderer->GetViewportSize().Height), GL_RGB16F, GL_RGB, GL_FLOAT);
+	CommonFunctions::GenerateTexture(&m_BloomTexture, GL_CLAMP_TO_BORDER, GL_LINEAR, glm::vec2(m_Renderer->GetViewportSize().Width, m_Renderer->GetViewportSize().Height), GL_RGB16F, GL_RGB, GL_FLOAT);
     m_FinalPassFrameBuffer.Generate();
 
     GLERROR("Error changing texture resolutions");

--- a/src/Engine/Rendering/DrawFinalPass.cpp
+++ b/src/Engine/Rendering/DrawFinalPass.cpp
@@ -1284,6 +1284,8 @@ void DrawFinalPass::DrawSprites(std::list<std::shared_ptr<RenderJob>>&jobs, Rend
             glUniform4fv(glGetUniformLocation(shaderHandle, "Color"), 1, glm::value_ptr(spriteJob->Color));
             glUniform4fv(glGetUniformLocation(shaderHandle, "FillColor"), 1, glm::value_ptr(spriteJob->FillColor));
             glUniform1f(glGetUniformLocation(shaderHandle, "FillPercentage"), spriteJob->FillPercentage);
+            glUniform1f(glGetUniformLocation(shaderHandle, "ScaleX"), spriteJob->ScaleX);
+            glUniform1f(glGetUniformLocation(shaderHandle, "ScaleY"), spriteJob->ScaleY);
 
             glActiveTexture(GL_TEXTURE1);
             if (spriteJob->DiffuseTexture != nullptr) {

--- a/src/Engine/Rendering/FrameBuffer.cpp
+++ b/src/Engine/Rendering/FrameBuffer.cpp
@@ -2,11 +2,12 @@
 #include "Rendering/FrameBuffer.h"
 
 
-BufferResource::BufferResource(GLuint* resourceHandle, GLenum resourceType, GLenum attachment)
+BufferResource::BufferResource(GLuint* resourceHandle, GLenum resourceType, GLenum attachment, GLuint mipMapLod)
 {
     m_ResourceHandle = resourceHandle;
     m_ResourceType = resourceType;
     m_Attachment = attachment;
+    m_MipMapLod = mipMapLod;
 }
 
 Texture2D::~Texture2D()
@@ -58,7 +59,7 @@ void FrameBuffer::Generate()
 	for (auto it = m_Resources.begin(); it != m_Resources.end(); it++) {
 		switch ((*it)->m_ResourceType) {
 		case GL_TEXTURE_2D:
-			glFramebufferTexture2D(GL_FRAMEBUFFER, (*it)->m_Attachment, (*it)->m_ResourceType, *(*it)->m_ResourceHandle, 0);
+			glFramebufferTexture(GL_FRAMEBUFFER, (*it)->m_Attachment, *(*it)->m_ResourceHandle, (*it)->m_MipMapLod);
 			GLERROR("FrameBuffer generate: glFramebufferTexture2D");
 			break;
 		case GL_RENDERBUFFER:

--- a/src/Engine/Rendering/SSAOPass.cpp
+++ b/src/Engine/Rendering/SSAOPass.cpp
@@ -233,6 +233,11 @@ void SSAOPass::Draw(GLuint depthBuffer, Camera* camera)
 	GLuint shaderHandle_horiz = m_GaussianProgram_horiz->GetHandle();
 	GLuint shaderHandle_vert = m_GaussianProgram_vert->GetHandle();
 
+    m_GaussianProgram_vert->Bind();
+    glUniform1i(glGetUniformLocation(shaderHandle_vert, "Lod"), 0);
+    m_GaussianProgram_horiz->Bind();
+    glUniform1i(glGetUniformLocation(shaderHandle_horiz, "Lod"), 0);
+
 	m_GaussianFrameBuffer_horiz.Bind();
 	m_GaussianProgram_horiz->Bind();
 
@@ -252,8 +257,6 @@ void SSAOPass::Draw(GLuint depthBuffer, Camera* camera)
 		glActiveTexture(GL_TEXTURE0);
 		glBindTexture(GL_TEXTURE_2D, m_Gaussian_horiz);
 
-		glBindVertexArray(m_ScreenQuad->VAO);
-		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_ScreenQuad->ElementBuffer);
 		glDrawElementsBaseVertex(GL_TRIANGLES, m_ScreenQuad->MaterialGroups()[0].material->EndIndex - m_ScreenQuad->MaterialGroups()[0].material->StartIndex + 1
 			, GL_UNSIGNED_INT, 0, m_ScreenQuad->MaterialGroups()[0].material->StartIndex);
 		//horizontal pass
@@ -265,8 +268,6 @@ void SSAOPass::Draw(GLuint depthBuffer, Camera* camera)
 		glActiveTexture(GL_TEXTURE0);
 		glBindTexture(GL_TEXTURE_2D, m_Gaussian_vert);
 
-		glBindVertexArray(m_ScreenQuad->VAO);
-		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_ScreenQuad->ElementBuffer);
 		glDrawElementsBaseVertex(GL_TRIANGLES, m_ScreenQuad->MaterialGroups()[0].material->EndIndex - m_ScreenQuad->MaterialGroups()[0].material->StartIndex + 1
 			, GL_UNSIGNED_INT, 0, m_ScreenQuad->MaterialGroups()[0].material->StartIndex);
 		m_GaussianFrameBuffer_horiz.Unbind();
@@ -279,8 +280,7 @@ void SSAOPass::Draw(GLuint depthBuffer, Camera* camera)
 
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(GL_TEXTURE_2D, m_Gaussian_horiz);
-	glBindVertexArray(m_ScreenQuad->VAO);
-	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_ScreenQuad->ElementBuffer);
+
 	glDrawElementsBaseVertex(GL_TRIANGLES, m_ScreenQuad->MaterialGroups()[0].material->EndIndex - m_ScreenQuad->MaterialGroups()[0].material->StartIndex + 1
 		, GL_UNSIGNED_INT, 0, m_ScreenQuad->MaterialGroups()[0].material->StartIndex);
 

--- a/src/Engine/Rendering/TextureSprite.cpp
+++ b/src/Engine/Rendering/TextureSprite.cpp
@@ -3,8 +3,8 @@
 TextureSprite::TextureSprite(std::string path)
     :Texture(path)
 {
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
     glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST_MIPMAP_NEAREST);
     glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST_MIPMAP_NEAREST);
     GLERROR("Texture load");

--- a/src/Engine/Rendering/TextureSprite.cpp
+++ b/src/Engine/Rendering/TextureSprite.cpp
@@ -6,6 +6,6 @@ TextureSprite::TextureSprite(std::string path)
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
     glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST_MIPMAP_NEAREST);
-    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST_MIPMAP_NEAREST);
+    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     GLERROR("Texture load");
 }

--- a/src/Engine/Rendering/Util/CommonFunctions.cpp
+++ b/src/Engine/Rendering/Util/CommonFunctions.cpp
@@ -28,7 +28,8 @@ void CommonFunctions::GenerateMipMapTexture(GLuint* texture, GLenum wrapping, gl
 	glGenTextures(1, texture);
 	glBindTexture(GL_TEXTURE_2D, *texture);
 	glTexStorage2D(GL_TEXTURE_2D, numMipMaps, GL_RGBA8, dimensions.x, dimensions.y);
-	glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, dimensions.x, dimensions.y, format, type, texture);
+	//glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, dimensions.x, dimensions.y, format, type, NULL);
+    GLERROR("MipMap Texture glTexSubImage2D failed");
 	glGenerateMipmap(GL_TEXTURE_2D);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrapping);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, wrapping);

--- a/src/Engine/Rendering/Util/CommonFunctions.cpp
+++ b/src/Engine/Rendering/Util/CommonFunctions.cpp
@@ -25,6 +25,7 @@ void CommonFunctions::GenerateMultiSampleTexture(GLuint* texture, int numSamples
 
 void CommonFunctions::GenerateMipMapTexture(GLuint* texture, GLenum wrapping, glm::vec2 dimensions, GLint format, GLenum type, GLint numMipMaps)
 {
+    glDeleteTextures(1, texture);
 	glGenTextures(1, texture);
 	glBindTexture(GL_TEXTURE_2D, *texture);
 	glTexStorage2D(GL_TEXTURE_2D, numMipMaps, GL_RGBA8, dimensions.x, dimensions.y);


### PR DESCRIPTION
## Added

**Sprites** now has _KeepRatio_ bools, to keep the ratio of the texture in X, Y or 1:1
**Bloom** is now looking like real bloom, instead of the shit we had before.
Some **Optimizations** in _SSAO_ and _Blur_ pass.
