### PR TITLE
The children of the CapturePointModels now also get their visibility changed

### DIFF
--- a/include/Game/Systems/CapturePointSystem.h
+++ b/include/Game/Systems/CapturePointSystem.h
@@ -30,6 +30,7 @@ private:
     bool CapturePointSystem::OnTriggerLeave(const Events::TriggerLeave& e);
     EventRelay<CapturePointSystem, Events::Captured> m_ECaptured;
     bool CapturePointSystem::OnCaptured(const Events::Captured& e);
+    void ChangeCapturePointModelsVisibility(EntityWrapper &capturePointModels, bool isOwner);
 
     bool m_WinnerWasFound = false;
     //need to track these variables for the captureSystem to work as per design!

--- a/resources/Schema/Entities/aim_rays_with_capturep.xml
+++ b/resources/Schema/Entities/aim_rays_with_capturep.xml
@@ -99,7 +99,7 @@
         </c:Team>
         <c:PlayerSpawn/>
         <c:Spawner>
-          <EntityFile>Schema/Entities/Player.xml</EntityFile>
+          <EntityFile>Schema/Entities/PlayerRed.xml</EntityFile>
         </c:Spawner>
         <c:Transform/>
       </Components>
@@ -225,6 +225,11 @@
               </Team>
             </c:Team>
             <c:Trigger/>
+            <c:Model>
+              <Resource></Resource>
+              <Color A="0.300000012" B="0" G="0" R="1"/>
+              <Visible>false</Visible>
+            </c:Model>
             <c:Transform>
               <Position X="0" Y="0" Z="-4.10000038"/>
             </c:Transform>
@@ -239,7 +244,17 @@
                   <Scale X="2.70000005" Y="3.4000001" Z="4.60000038"/>
                 </c:Transform>
               </Components>
-              <Children/>
+              <Children>
+                <Entity>
+                  <Components>
+                    <c:Model>
+                      <Resource></Resource>
+                    </c:Model>
+                    <c:Transform/>
+                  </Components>
+                  <Children/>
+                </Entity>
+              </Children>
             </Entity>
             <Entity name="Blue">
               <Components>

--- a/src/Game/Systems/CapturePointSystem.cpp
+++ b/src/Game/Systems/CapturePointSystem.cpp
@@ -109,9 +109,9 @@ void CapturePointSystem::UpdateComponent(EntityWrapper& capturePointEntity, Comp
         for (int i = 0; i < m_NumberOfCapturePoints; i++) {
             auto owner = (int)m_CapturePointNumberToEntityMap[i]["Team"]["Team"];
             if (m_CapturePointNumberToEntityMap[i].FirstChildByName("Red").ID != EntityID_Invalid) {
-                (bool&)m_CapturePointNumberToEntityMap[i].FirstChildByName("Red")["Model"]["Visible"] = owner == redTeam ? true : false;
-                (bool&)m_CapturePointNumberToEntityMap[i].FirstChildByName("Blue")["Model"]["Visible"] = owner == blueTeam ? true : false;
-                (bool&)m_CapturePointNumberToEntityMap[i].FirstChildByName("Spectator")["Model"]["Visible"] = owner == spectatorTeam ? true : false;
+                ChangeCapturePointModelsVisibility(m_CapturePointNumberToEntityMap[i].FirstChildByName("Red"), owner == redTeam);
+                ChangeCapturePointModelsVisibility(m_CapturePointNumberToEntityMap[i].FirstChildByName("Blue"), owner == blueTeam);
+                ChangeCapturePointModelsVisibility(m_CapturePointNumberToEntityMap[i].FirstChildByName("Spectator"), owner == spectatorTeam);
             }
         }
         //save the next cap points and publish the captured event
@@ -230,6 +230,14 @@ void CapturePointSystem::UpdateComponent(EntityWrapper& capturePointEntity, Comp
         m_WinnerWasFound = true;
     }
 
+}
+
+void CapturePointSystem::ChangeCapturePointModelsVisibility(EntityWrapper &capturePointModels, bool isOwner) {
+    (bool&)capturePointModels["Model"]["Visible"] = isOwner;
+    for (auto& capModel : capturePointModels.ChildrenWithComponent("Model"))
+    {
+        (bool&)capModel["Model"]["Visible"] = isOwner;
+    }
 }
 
 bool CapturePointSystem::OnTriggerTouch(const Events::TriggerTouch& e)

--- a/src/Game/Systems/CapturePointSystem.cpp
+++ b/src/Game/Systems/CapturePointSystem.cpp
@@ -108,7 +108,7 @@ void CapturePointSystem::UpdateComponent(EntityWrapper& capturePointEntity, Comp
         //change what model is displaying (change all in case 2 capturepoints has been captured on the same frame)
         for (int i = 0; i < m_NumberOfCapturePoints; i++) {
             auto owner = (int)m_CapturePointNumberToEntityMap[i]["Team"]["Team"];
-            if (m_CapturePointNumberToEntityMap[i].FirstChildByName("Red").ID != EntityID_Invalid) {
+            if (m_CapturePointNumberToEntityMap[i].FirstChildByName("Red").Valid()) {
                 ChangeCapturePointModelsVisibility(m_CapturePointNumberToEntityMap[i].FirstChildByName("Red"), owner == redTeam);
                 ChangeCapturePointModelsVisibility(m_CapturePointNumberToEntityMap[i].FirstChildByName("Blue"), owner == blueTeam);
                 ChangeCapturePointModelsVisibility(m_CapturePointNumberToEntityMap[i].FirstChildByName("Spectator"), owner == spectatorTeam);


### PR DESCRIPTION
- The children of the CapturePointModels now also get their visibility changed
  on/off. This is done since a capturepoint is actually 2 models and not just 1
