### PR TITLE
Triggersystem updated for the capturepoints

### DIFF
--- a/include/Engine/Collision/Collision.h
+++ b/include/Engine/Collision/Collision.h
@@ -84,6 +84,18 @@ bool AABBvsTriangles(const AABB& box,
     const std::vector<unsigned int>& modelIndices,
     const glm::mat4& modelMatrix);
 
+enum Output
+{
+    OutContained,
+    OutSeparated,
+    OutIntersecting
+};
+//Detects intersection and containment.
+Output AABBvsTrianglesWContainment(const AABB& box,
+    const RawModel::Vertex* modelVertices,
+    const std::vector<unsigned int>& modelIndices,
+    const glm::mat4& modelMatrix);
+
 //Return true if the boxes are intersecting.
 bool AABBVsAABB(const AABB& a, const AABB& b);
 //Return true if the boxes are intersecting.

--- a/src/Engine/Collision/Collision.cpp
+++ b/src/Engine/Collision/Collision.cpp
@@ -360,7 +360,14 @@ constexpr bool FaceIsGround(float faceNormalY)
 //An array containing 3 int pairs { 0, 2 }, { 0, 1 }, { 1, 2 }
 constexpr std::array<std::pair<int, int>, 3> dimensionPairs({ std::pair<int, int>(0, 2), std::pair<int, int>(0, 1), std::pair<int, int>(1, 2) });
 
-bool AABBvsTriangle(const AABB& box,
+enum class BoxTriRes
+{
+    Front,
+    Behind,
+    Intersect
+};
+
+BoxTriRes AABBvsTriangle(const AABB& box,
     const std::array<glm::vec3, 3>& triPos,
     const glm::vec3& originalBoxVelocity,
     float verticalStepHeight,
@@ -374,7 +381,7 @@ bool AABBvsTriangle(const AABB& box,
     //Less checks, and we should be able to walk out from models if we are trapped inside.
     glm::vec3 triNormal = glm::cross(triPos[1] - triPos[0], triPos[2] - triPos[0]);
     if (!vectorHasLength(triNormal) || (glm::dot(triNormal, originalBoxVelocity) > 0)) {
-        return false;
+        return BoxTriRes::Behind;
     }
     triNormal = glm::normalize(triNormal);
 
@@ -409,6 +416,9 @@ bool AABBvsTriangle(const AABB& box,
     const glm::vec3& min = box.MinCorner();
     const glm::vec3& max = box.MaxCorner();
 
+    // If there is no intersection, whether the box center is in front of or behind the triangle.
+    BoxTriRes noIntersection = glm::dot(triNormal, origin - triPos[0]) > 0 ? BoxTriRes::Front : BoxTriRes::Behind;
+
     //For each projection in xy-, xz-, and yx-planes.
     for (std::pair<int, int> dim : dimensionPairs) {
         //2D Triangle.
@@ -426,7 +436,7 @@ bool AABBvsTriangle(const AABB& box,
         bool pushedFromTriangleLine;
         //if projections don't overlap, return false.
         if (!rectangleVsTriangle(boxMin, boxMax, t2D, resolutionVector, resolutionDist, pushedFromTriangleLine)) {
-            return false;
+            return noIntersection;
         } else if (resolveCollision) {
             //Overwrite the smallest resolution if this is smaller.
             if (resolutionDist < resolveShortest.DistanceSq) {
@@ -462,11 +472,11 @@ bool AABBvsTriangle(const AABB& box,
     float t = glm::dot(triNormal, triPos[0] - origin) / glm::dot(triNormal, diagonal);
     //If intersection point between plane and diagonal is within the box.
     if (glm::abs(t) > 1) {
-        return false;
+        return noIntersection;
     }
 
     if (!resolveCollision) {
-        return true;
+        return BoxTriRes::Intersect;
     }
 
     glm::vec3 cornerResolution = (1+t) * diagonal;
@@ -498,7 +508,7 @@ bool AABBvsTriangle(const AABB& box,
     case ResolveDimZ:
         //If we get here, the resolution is along one coordinate axis.
         //set velocity to 0 in y if it is along y-axis.
-        return true;
+        return BoxTriRes::Intersect;
     case Line:
         projNorm = glm::normalize(outResolution);
         break;
@@ -533,10 +543,10 @@ bool AABBvsTriangle(const AABB& box,
             boxVelocity = boxVelocity - glm::dot(boxVelocity, projNorm) * projNorm;
         }
     }
-    return true;
+    return BoxTriRes::Intersect;
 }
 
-bool AABBvsTriangles(const AABB& box,
+Output AABBvsTriangles(const AABB& box,
     const RawModel::Vertex* modelVertices,
     const std::vector<unsigned int>& modelIndices,
     const glm::mat4& modelMatrix,
@@ -546,8 +556,8 @@ bool AABBvsTriangles(const AABB& box,
     glm::vec3& outResolutionVector,
     bool resolveCollision)
 {
-    bool hit = false;
-
+    bool intersect = false;
+    Output out = Output::OutContained;
     bool everHitTheGround = false;
     AABB newBox = box;
     outResolutionVector = glm::vec3(0.f);
@@ -560,20 +570,27 @@ bool AABBvsTriangles(const AABB& box,
         };
         glm::vec3 outVec;
         bool collideWithGround = isOnGround;
-        if (AABBvsTriangle(newBox, triVertices, originalBoxVelocity, verticalStepHeight, collideWithGround, boxVelocity, outVec, resolveCollision)) {
-            hit = true;
+        switch (AABBvsTriangle(newBox, triVertices, originalBoxVelocity, verticalStepHeight, collideWithGround, boxVelocity, outVec, resolveCollision)) {
+        case Collision::BoxTriRes::Front:
+            out = Output::OutSeparated;
+            break;
+        case Collision::BoxTriRes::Intersect:
+            intersect = true;
             outResolutionVector += outVec;
             newBox = AABB::FromOriginSize(newBox.Origin() + outVec, newBox.Size());
             if (collideWithGround) {
                 everHitTheGround = isOnGround = true;
             }
+            break;
+        default:
+            break;
         }
     }
 
     if (!everHitTheGround) {
         isOnGround = false;
     }
-    return hit;
+    return intersect ? Output::OutIntersecting : out;
 }
 
 bool AABBvsTriangles(const AABB& box,
@@ -593,10 +610,28 @@ bool AABBvsTriangles(const AABB& box,
         verticalStepHeight,
         isOnGround,
         outResolutionVector,
-        true);
+        true) == Output::OutIntersecting;
 }
 
 bool AABBvsTriangles(const AABB& box,
+    const RawModel::Vertex* modelVertices,
+    const std::vector<unsigned int>& modelIndices,
+    const glm::mat4& modelMatrix)
+{
+    glm::vec3 vel, outres;
+    bool g;
+    return AABBvsTriangles(box,
+        modelVertices,
+        modelIndices,
+        modelMatrix,
+        vel,
+        0.f,
+        g,
+        outres,
+        false) == Output::OutIntersecting;
+}
+
+Output AABBvsTrianglesWContainment(const AABB& box,
     const RawModel::Vertex* modelVertices,
     const std::vector<unsigned int>& modelIndices,
     const glm::mat4& modelMatrix)

--- a/src/Engine/Collision/CollisionSystem.cpp
+++ b/src/Engine/Collision/CollisionSystem.cpp
@@ -37,6 +37,10 @@ void CollisionSystem::UpdateComponent(EntityWrapper& entity, ComponentWrapper& c
                     bool hit;
                     float dist;
                     if (boxB.Entity.HasComponent("Model")) {
+                        if (!((bool)boxB.Entity["Model"]["Visible"])) {
+                            // Don't collide against invisible models.
+                            continue;
+                        }
                         RawModel* model;
                         std::string res = (std::string)boxB.Entity["Model"]["Resource"];
                         try {
@@ -77,7 +81,11 @@ void CollisionSystem::UpdateComponent(EntityWrapper& entity, ComponentWrapper& c
             }
 
             if (boxB.Entity.HasComponent("Model") && Collision::AABBVsAABB(boxA, boxB)) {
-                //Here we know boxB is a entity with Collideable, AABB, and Model.
+                // Here we know boxB is a entity with Collideable, AABB, and Model.
+                if (!((bool)boxB.Entity["Model"]["Visible"])) {
+                    // Don't collide against invisible models.
+                    continue;
+                }
                 RawModel* model;
                 try {
                     model = ResourceManager::Load<RawModel, true>(boxB.Entity["Model"]["Resource"]);


### PR DESCRIPTION
Triggers are now triggered when their model is intersected utilizing the model vs. box collision code. Which means that our cylindrical capturepoints won't be treated as boxes anymore.

Also added a check so we will not collide against invisible models, such the 2 disabled models of the capturepoints. 
