### PR TITLE
Getting ShaderID fewer times

### DIFF
--- a/include/Engine/Rendering/ModelJob.h
+++ b/include/Engine/Rendering/ModelJob.h
@@ -26,24 +26,13 @@ struct ModelJob : RenderJob
 		ModelID = model->ResourceID;
 		Type = matProp.type;
 		::RawModel::MaterialBasic* matGroup = matProp.material;
+		ShaderID = matProp.ShaderID;
 		switch(matProp.type){
 		case ::RawModel::MaterialType::Basic:
-			if (Model->IsSkinned()) {
-				ShaderID = ResourceManager::Load<ShaderProgram>("#ForwardPlusSkinnedProgram")->ResourceID;
-			}
-			else {
-				ShaderID = ResourceManager::Load<ShaderProgram>("#ForwardPlusProgram")->ResourceID;
-			}
 			TextureID = 0;
 			break;
 		case ::RawModel::MaterialType::SingleTextures:
 			{
-				if (Model->IsSkinned()) {
-					ShaderID = ResourceManager::Load<ShaderProgram>("#ForwardPlusSkinnedProgram")->ResourceID;
-				}
-				else {
-					ShaderID = ResourceManager::Load<ShaderProgram>("#ForwardPlusProgram")->ResourceID;
-				}
 				::RawModel::MaterialSingleTextures* singleTextures = static_cast<::RawModel::MaterialSingleTextures*>(matProp.material);
 				TextureID = (singleTextures->ColorMap.Texture) ? singleTextures->ColorMap.Texture->ResourceID : 0;
 				if (modelComponent["DiffuseTexture"]) {
@@ -65,12 +54,6 @@ struct ModelJob : RenderJob
 			break;
 		case ::RawModel::MaterialType::SplatMapping:
 			{
-				if (Model->IsSkinned()) {
-					ShaderID = ResourceManager::Load<ShaderProgram>("#ForwardPlusSplatMapSkinnedProgram")->ResourceID;
-				}
-				else {
-					ShaderID = ResourceManager::Load<ShaderProgram>("#ForwardPlusSplatMapProgram")->ResourceID;
-				}
 				::RawModel::MaterialSplatMapping* SplatTextures = static_cast<::RawModel::MaterialSplatMapping*>(matProp.material);
 
 				SplatMap = &SplatTextures->SplatMap;

--- a/include/Engine/Rendering/RawModelCustom.h
+++ b/include/Engine/Rendering/RawModelCustom.h
@@ -18,6 +18,7 @@
 #include "../Core/ResourceManager.h"
 #include "Texture.h"
 #include "Skeleton.h"
+#include "ShaderProgram.h"
 
 #include "boost\endian\buffers.hpp"
 
@@ -87,6 +88,7 @@ public:
 	struct MaterialProperties {
 		MaterialType type;
 		MaterialBasic* material;
+		unsigned int ShaderID = 0;
 	};
 
 	const Vertex*	Vertices() const {

--- a/src/Engine/Rendering/RawModelCustom.cpp
+++ b/src/Engine/Rendering/RawModelCustom.cpp
@@ -148,14 +148,29 @@ void RawModelCustom::ReadMaterialSingle(std::size_t& offset, char* fileData, con
 	case MaterialType::Basic:
 		newMaterialProperty.material = new MaterialBasic();
 		ReadMaterialBasic(newMaterialProperty.material, offset, fileData, fileByteSize);
+		if(hasSkin){
+			newMaterialProperty.ShaderID = ResourceManager::Load<ShaderProgram>("#ForwardPlusSkinnedProgram")->ResourceID;
+		} else {
+			newMaterialProperty.ShaderID = ResourceManager::Load<ShaderProgram>("#ForwardPlusProgram")->ResourceID;
+		}
 		break;
 	case MaterialType::SplatMapping:
 		newMaterialProperty.material = new MaterialSplatMapping();
 		ReadMaterialSplatMapping(static_cast<MaterialSplatMapping*>(newMaterialProperty.material), offset, fileData, fileByteSize);
+		if (hasSkin){
+			newMaterialProperty.ShaderID = ResourceManager::Load<ShaderProgram>("#ForwardPlusSplatMapSkinnedProgram")->ResourceID;
+		} else {
+			newMaterialProperty.ShaderID = ResourceManager::Load<ShaderProgram>("#ForwardPlusSplatMapProgram")->ResourceID;
+		}
 		break;
 	case MaterialType::SingleTextures:
 		newMaterialProperty.material = new MaterialSingleTextures();
 		ReadMaterialSingleTexture(static_cast<MaterialSingleTextures*>(newMaterialProperty.material), offset, fileData, fileByteSize);
+		if (hasSkin){
+			newMaterialProperty.ShaderID = ResourceManager::Load<ShaderProgram>("#ForwardPlusSkinnedProgram")->ResourceID;
+		} else {
+			newMaterialProperty.ShaderID = ResourceManager::Load<ShaderProgram>("#ForwardPlusProgram")->ResourceID;
+		}
 		break;
 	default:
 		throw Resource::FailedLoadingException("Material contains an unknown MaterialType");


### PR DESCRIPTION
Getting ShaderID one time per material in total instead of several times every frame (one time per material per instance of mesh).
